### PR TITLE
Revise .travis.yml to have session info in output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,13 @@ sudo: required
 notifications:
   email:
     on_success: change
-    on_failure: change
+    on_failure: always
+
+before_script:
+  - export PKG_NAME=$(Rscript -e 'cat(paste0(devtools::as.package(".")$package))')
+  - export PKG_TARBALL=$(Rscript -e 'pkg <- devtools::as.package("."); cat(paste0(pkg$package,"_",pkg$version,".tar.gz"))')
+  - R CMD build .
+  - R CMD INSTALL ${PKG_TARBALL}
+  - rm ${PKG_TARBALL}
+  - echo "Session info:"
+  - Rscript -e "library(${PKG_NAME});devtools::session_info('${PKG_NAME}')"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ notifications:
 before_script:
   - export PKG_NAME=$(Rscript -e 'cat(paste0(devtools::as.package(".")$package))')
   - export PKG_TARBALL=$(Rscript -e 'pkg <- devtools::as.package("."); cat(paste0(pkg$package,"_",pkg$version,".tar.gz"))')
-  - R CMD build .
+  - R CMD build --no-build-vignettes .
   - R CMD INSTALL ${PKG_TARBALL}
   - rm ${PKG_TARBALL}
   - echo "Session info:"


### PR DESCRIPTION
I spent more time then necessary trying to work out a bug in [qtl2geno](https://github.com/rqtl/qtl2geno) that arose due to an update in the [data.table](https://github.com/Rdatatable/data.table) package on CRAN. A comparison of the package versions on Travis vs locally would have helped. (Or I should just run `update.packages(ask=FALSE)` whenever I see a difference between Travis and local tests.)

It's a bit tricky to get session information in the case of a failure (which is what we care about), because the script on travis seems to overwrite any attempt to customize `after_failure`, and `after_script` isn't run if there's a failure, so we're stuck with `before_script`.
