### PR TITLE
Add some basic C++ functions for 1-QTL scan of a chromosome

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2scan
-Version: 0.3-5
+Version: 0.3-6
 Date: 2015-11-30
 Title: Genome Scans for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.3-6
-Date: 2015-11-30
+Version: 0.3-7
+Date: 2015-12-01
 Title: Genome Scans for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -109,6 +109,10 @@ find_lin_indep_cols <- function(mat, tol = 1e-12) {
     .Call('qtl2scan_find_lin_indep_cols', PACKAGE = 'qtl2scan', mat, tol)
 }
 
+formX_intcovar <- function(probs, addcovar, intcovar) {
+    .Call('qtl2scan_formX_intcovar', PACKAGE = 'qtl2scan', probs, addcovar, intcovar)
+}
+
 random_int <- function(n, low, high) {
     .Call('qtl2scan_random_int', PACKAGE = 'qtl2scan', n, low, high)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -113,6 +113,14 @@ formX_intcovar <- function(probs, addcovar, intcovar) {
     .Call('qtl2scan_formX_intcovar', PACKAGE = 'qtl2scan', probs, addcovar, intcovar)
 }
 
+weighted_matrix <- function(mat, weights) {
+    .Call('qtl2scan_weighted_matrix', PACKAGE = 'qtl2scan', mat, weights)
+}
+
+weighted_3darray <- function(array, weights) {
+    .Call('qtl2scan_weighted_3darray', PACKAGE = 'qtl2scan', array, weights)
+}
+
 random_int <- function(n, low, high) {
     .Call('qtl2scan_random_int', PACKAGE = 'qtl2scan', n, low, high)
 }
@@ -139,5 +147,13 @@ permute_ivector_stratified <- function(n_perm, x, strata, n_strata = -1L) {
 
 scan_hk_onechr_nocovar <- function(genoprobs, pheno, tol = 1e-12) {
     .Call('qtl2scan_scan_hk_onechr_nocovar', PACKAGE = 'qtl2scan', genoprobs, pheno, tol)
+}
+
+scan_hk_onechr <- function(genoprobs, pheno, addcovar, tol = 1e-12) {
+    .Call('qtl2scan_scan_hk_onechr', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, tol)
+}
+
+scan_hk_onechr_weighted <- function(genoprobs, pheno, addcovar, weights, tol = 1e-12) {
+    .Call('qtl2scan_scan_hk_onechr_weighted', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, weights, tol)
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -441,13 +441,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // scan_hk_onechr_nocovar
-NumericMatrix scan_hk_onechr_nocovar(NumericVector genoprobs, NumericMatrix pheno, const double tol);
+NumericMatrix scan_hk_onechr_nocovar(const NumericVector& genoprobs, const NumericMatrix& pheno, const double tol);
 RcppExport SEXP qtl2scan_scan_hk_onechr_nocovar(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP tolSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< NumericVector >::type genoprobs(genoprobsSEXP);
-    Rcpp::traits::input_parameter< NumericMatrix >::type pheno(phenoSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type genoprobs(genoprobsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type pheno(phenoSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     __result = Rcpp::wrap(scan_hk_onechr_nocovar(genoprobs, pheno, tol));
     return __result;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -364,6 +364,30 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// weighted_matrix
+NumericMatrix weighted_matrix(const NumericMatrix& mat, const NumericVector& weights);
+RcppExport SEXP qtl2scan_weighted_matrix(SEXP matSEXP, SEXP weightsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type mat(matSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
+    __result = Rcpp::wrap(weighted_matrix(mat, weights));
+    return __result;
+END_RCPP
+}
+// weighted_3darray
+NumericVector weighted_3darray(const NumericVector& array, const NumericVector& weights);
+RcppExport SEXP qtl2scan_weighted_3darray(SEXP arraySEXP, SEXP weightsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericVector& >::type array(arraySEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
+    __result = Rcpp::wrap(weighted_3darray(array, weights));
+    return __result;
+END_RCPP
+}
 // random_int
 IntegerVector random_int(const int n, const int low, const int high);
 RcppExport SEXP qtl2scan_random_int(SEXP nSEXP, SEXP lowSEXP, SEXP highSEXP) {
@@ -450,6 +474,35 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const NumericMatrix& >::type pheno(phenoSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
     __result = Rcpp::wrap(scan_hk_onechr_nocovar(genoprobs, pheno, tol));
+    return __result;
+END_RCPP
+}
+// scan_hk_onechr
+NumericMatrix scan_hk_onechr(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const double tol);
+RcppExport SEXP qtl2scan_scan_hk_onechr(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP tolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericVector& >::type genoprobs(genoprobsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type pheno(phenoSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
+    Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
+    __result = Rcpp::wrap(scan_hk_onechr(genoprobs, pheno, addcovar, tol));
+    return __result;
+END_RCPP
+}
+// scan_hk_onechr_weighted
+NumericMatrix scan_hk_onechr_weighted(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericVector& weights, const double tol);
+RcppExport SEXP qtl2scan_scan_hk_onechr_weighted(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP weightsSEXP, SEXP tolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericVector& >::type genoprobs(genoprobsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type pheno(phenoSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
+    __result = Rcpp::wrap(scan_hk_onechr_weighted(genoprobs, pheno, addcovar, weights, tol));
     return __result;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -351,6 +351,19 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// formX_intcovar
+NumericMatrix formX_intcovar(const NumericMatrix& probs, const NumericMatrix& addcovar, const NumericMatrix& intcovar);
+RcppExport SEXP qtl2scan_formX_intcovar(SEXP probsSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type probs(probsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type intcovar(intcovarSEXP);
+    __result = Rcpp::wrap(formX_intcovar(probs, addcovar, intcovar));
+    return __result;
+END_RCPP
+}
 // random_int
 IntegerVector random_int(const int n, const int low, const int high);
 RcppExport SEXP qtl2scan_random_int(SEXP nSEXP, SEXP lowSEXP, SEXP highSEXP) {

--- a/src/linreg.cpp
+++ b/src/linreg.cpp
@@ -32,13 +32,15 @@ NumericVector calc_resid_linreg_3d(const NumericMatrix& X, const NumericVector& 
                                    const double tol=1e-12)
 {
     const unsigned int nrowx = X.rows();
-    const unsigned int sizep = P.size();
+    const Dimension d = P.attr("dim");
+    if(d[0] != nrowx)
+        throw std::range_error("nrow(X) != nrow(P)");
 
-    NumericMatrix pr(nrowx, sizep/nrowx);
+    NumericMatrix pr(nrowx, d[1]*d[2]);
     std::copy(P.begin(), P.end(), pr.begin()); // FIXME I shouldn't need to copy
 
     NumericMatrix result = calc_resid_eigenqr(X, pr, tol);
-    result.attr("dim") = P.attr("dim");
+    result.attr("dim") = d;
 
     return result;
 }

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -279,3 +279,33 @@ IntegerVector find_lin_indep_cols(const NumericMatrix& mat, const double tol=1e-
 
     return result;
 }
+
+// form X matrix with intcovar
+// [[Rcpp::export]]
+NumericMatrix formX_intcovar(const NumericMatrix& probs,
+                             const NumericMatrix& addcovar,
+                             const NumericMatrix& intcovar)
+{
+    const unsigned int nrow  = probs.rows();
+    const unsigned int nprob = probs.cols();
+    const unsigned int nadd  = addcovar.cols();
+    const unsigned int nint  = intcovar.cols();
+
+    if(addcovar.rows() != nrow)
+        throw std::range_error("nrow(addcovar) != nrow(probs)");
+    if(intcovar.rows() != nrow)
+        throw std::range_error("nrow(intcovar) != nrow(probs)");
+
+    NumericMatrix result(nrow,nadd+nprob+nprob*nint);
+    std::copy(addcovar.begin(), addcovar.end(), result.begin());
+    std::copy(probs.begin(), probs.end(), result.begin() + nrow*nadd);
+
+    for(unsigned int i=0, rescol=nprob+nadd; i<nint; i++) {
+        for(unsigned int j=0; j<nprob; j++, rescol++) {
+            for(unsigned int k=0; k<nrow; k++)
+                result(k,rescol) = probs(k,j)*intcovar(k,i);
+        }
+    }
+
+    return result;
+}

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -309,3 +309,43 @@ NumericMatrix formX_intcovar(const NumericMatrix& probs,
 
     return result;
 }
+
+// multiply each column of a matrix by a set of weights
+// [[Rcpp::export]]
+NumericMatrix weighted_matrix(const NumericMatrix& mat,
+                              const NumericVector& weights)
+{
+    const unsigned int nrow = mat.rows();
+    const unsigned int ncol = mat.cols();
+    if(nrow != weights.size())
+        throw std::range_error("nrow(mat) != length(weights)");
+
+    NumericMatrix result(nrow,ncol);
+
+    for(unsigned int j=0; j<ncol; j++)
+        for(unsigned int i=0; i<nrow; i++)
+            result(i,j) = mat(i,j)*weights[i];
+
+    return result;
+}
+
+// multiply each column of a 3-dimensional array by a set of weights
+// [[Rcpp::export]]
+NumericVector weighted_3darray(const NumericVector& array,
+                               const NumericVector& weights)
+{
+    const Dimension d = array.attr("dim");
+    const unsigned int n = d[0];
+    const unsigned int ncol = d[1]*d[2];
+    if(n != weights.size())
+        throw std::range_error("nrow(array) != length(weights)");
+
+    NumericVector result(n*ncol);
+    result.attr("dim") = d;
+
+    for(unsigned int j=0, k=0; j<ncol; j++)
+        for(unsigned int i=0; i<n; i++, k++)
+            result[k] = array[k]*weights[i];
+
+    return result;
+}

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -45,4 +45,12 @@ Rcpp::NumericMatrix formX_intcovar(const Rcpp::NumericMatrix& probs,
                                    const Rcpp::NumericMatrix& addcovar,
                                    const Rcpp::NumericMatrix& intcovar);
 
+// multiply each column of a matrix by a set of weights
+Rcpp::NumericMatrix weighted_matrix(const Rcpp::NumericMatrix& mat,
+                              const Rcpp::NumericVector& weights);
+
+// multiply each element of a vector by the corresponding weight
+Rcpp::NumericVector weighted_3darray(const Rcpp::NumericVector& array,
+                                     const Rcpp::NumericVector& weights);
+
 #endif // MATRIX_H

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -40,4 +40,9 @@ Rcpp::NumericVector find_matching_cols(const Rcpp::NumericMatrix& mat,
 Rcpp::IntegerVector find_lin_indep_cols(const Rcpp::NumericMatrix& mat,
                                         const double tol);
 
+// form X matrix with intcovar
+Rcpp::NumericMatrix formX_intcovar(const Rcpp::NumericMatrix& probs,
+                                   const Rcpp::NumericMatrix& addcovar,
+                                   const Rcpp::NumericMatrix& intcovar);
+
 #endif // MATRIX_H

--- a/src/scan_hk.cpp
+++ b/src/scan_hk.cpp
@@ -16,7 +16,7 @@ using namespace Rcpp;
 // output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
 //
 // [[Rcpp::export]]
-NumericMatrix scan_hk_onechr_nocovar(NumericVector genoprobs, NumericMatrix pheno,
+NumericMatrix scan_hk_onechr_nocovar(const NumericVector& genoprobs, const NumericMatrix& pheno,
                                      const double tol=1e-12)
 {
     const unsigned int n_ind = pheno.rows();

--- a/src/scan_hk.cpp
+++ b/src/scan_hk.cpp
@@ -61,7 +61,6 @@ NumericMatrix scan_hk_onechr(const NumericVector& genoprobs, const NumericMatrix
     const unsigned int n_phe = pheno.cols();
     const Dimension d = genoprobs.attr("dim");
     const unsigned int n_pos = d[2];
-    const unsigned int n_gen = d[1];
     if(n_ind != d[0])
         throw std::range_error("nrow(pheno) != nrow(genoprobs)");
     if(n_ind != addcovar.rows())
@@ -94,7 +93,6 @@ NumericMatrix scan_hk_onechr_weighted(const NumericVector& genoprobs, const Nume
     const unsigned int n_phe = pheno.cols();
     const Dimension d = genoprobs.attr("dim");
     const unsigned int n_pos = d[2];
-    const unsigned int n_gen = d[1];
     if(n_ind != d[0])
         throw std::range_error("nrow(pheno) != nrow(genoprobs)");
     if(n_ind != addcovar.rows())

--- a/src/scan_hk.cpp
+++ b/src/scan_hk.cpp
@@ -6,6 +6,7 @@
 using namespace Rcpp;
 
 #include "linreg.h"
+#include "matrix.h"
 
 // Scan a single chromosome with no additive covariates (not even intercept)
 //
@@ -72,4 +73,48 @@ NumericMatrix scan_hk_onechr(const NumericVector& genoprobs, const NumericMatrix
     NumericMatrix pheno_resid = calc_resid_linreg(addcovar, pheno, tol);
 
     return scan_hk_onechr_nocovar(genoprob_resid, pheno_resid, tol);
+}
+
+// Scan a single chromosome with additive covariates and weights
+//
+// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// pheno     = matrix of numeric phenotypes (individuals x phenotypes)
+//             (no missing data allowed)
+// addcovar  = additive covariates (an intercept, at least)
+// weights   = vector of weights (really the SQUARE ROOT of the weights)
+//
+// output    = matrix of (weighted) residual sums of squares (RSS) (phenotypes x positions)
+//
+// [[Rcpp::export]]
+NumericMatrix scan_hk_onechr_weighted(const NumericVector& genoprobs, const NumericMatrix& pheno,
+                                      const NumericMatrix& addcovar, const NumericVector& weights,
+                                      const double tol=1e-12)
+{
+    const unsigned int n_ind = pheno.rows();
+    const unsigned int n_phe = pheno.cols();
+    const Dimension d = genoprobs.attr("dim");
+    const unsigned int n_pos = d[2];
+    const unsigned int n_gen = d[1];
+    if(n_ind != d[0])
+        throw std::range_error("nrow(pheno) != nrow(genoprobs)");
+    if(n_ind != addcovar.rows())
+        throw std::range_error("nrow(pheno) != nrow(addcovar)");
+    if(n_ind != weights.size())
+        throw std::range_error("nrow(pheno) != length(weights)");
+
+    // to contain the result
+    NumericMatrix result(n_phe, n_pos);
+
+    // multiply everything by the (square root) of the weights
+    // (weights should ALREADY be the square-root of the real weights)
+    NumericMatrix addcovar_wt = weighted_matrix(addcovar, weights);
+    NumericMatrix pheno_wt = weighted_matrix(pheno, weights);
+    NumericVector genoprobs_wt = weighted_3darray(genoprobs, weights);
+
+    // now regress out the additive covariates
+    genoprobs_wt = calc_resid_linreg_3d(addcovar_wt, genoprobs_wt, tol);
+    pheno_wt = calc_resid_linreg(addcovar_wt, pheno_wt, tol);
+
+    // now the scan
+    return scan_hk_onechr_nocovar(genoprobs_wt, pheno_wt, tol);
 }

--- a/src/scan_hk.h
+++ b/src/scan_hk.h
@@ -16,4 +16,18 @@ Rcpp::NumericMatrix scan_hk_onechr_nocovar(const Rcpp::NumericVector& genoprobs,
                                            const Rcpp::NumericMatrix& pheno,
                                            const double tol);
 
+
+// Scan a single chromosome with additive covariates
+//
+// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// pheno     = matrix of numeric phenotypes (individuals x phenotypes)
+//             (no missing data allowed)
+// addcovar  = additive covariates (an intercept, at least)
+//
+// output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
+Rcpp::NumericMatrix scan_hk_onechr(const Rcpp::NumericVector& genoprobs,
+                                   const Rcpp::NumericMatrix& pheno,
+                                   const Rcpp::NumericMatrix& addcovar,
+                                   const double tol);
+
 #endif // SCAN_HK_H

--- a/src/scan_hk.h
+++ b/src/scan_hk.h
@@ -30,4 +30,19 @@ Rcpp::NumericMatrix scan_hk_onechr(const Rcpp::NumericVector& genoprobs,
                                    const Rcpp::NumericMatrix& addcovar,
                                    const double tol);
 
+// Scan a single chromosome with additive covariates and weights
+//
+// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// pheno     = matrix of numeric phenotypes (individuals x phenotypes)
+//             (no missing data allowed)
+// addcovar  = additive covariates (an intercept, at least)
+// weights   = vector of weights (really the SQUARE ROOT of the weights)
+//
+// output    = matrix of (weighted) residual sums of squares (RSS) (phenotypes x positions)
+Rcpp::NumericMatrix scan_hk_onechr_weighted(const Rcpp::NumericVector& genoprobs,
+                                            const Rcpp::NumericMatrix& pheno,
+                                            const Rcpp::NumericMatrix& addcovar,
+                                            const Rcpp::NumericVector& weights,
+                                            const double tol);
+
 #endif // SCAN_HK_H

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -77,7 +77,7 @@ test_that("formX_intcovar works", {
     intcovar <- addcovar[,2,drop=FALSE]
 
     X <- formX_intcovar(prob, addcovar, intcovar)
-    expected <- cbind(addcovar, prob, prob*as.numeric(intcovar))
+    expected <- cbind(addcovar, prob, prob*intcovar[,1]) # the [,1] makes intcovar an ordinary vector
     expect_equal(X, expected)
 
     # no interactive covariates
@@ -89,5 +89,14 @@ test_that("formX_intcovar works", {
     # mismatch in rows
     expect_error(formX_intcovar(prob, addcovar[-n,], intcovar))
     expect_error(formX_intcovar(prob, addcovar, intcovar[-1,]))
+
+    # two interactive covariates
+    addcovar <- cbind(addcovar, sample(0:1, n, replace=TRUE))
+
+    intcovar <- addcovar[,-1]
+
+    X <- formX_intcovar(prob, addcovar, intcovar)
+    expected <- cbind(addcovar, prob, prob*intcovar[,1], prob*intcovar[,2])
+    expect_equal(X, expected)
 
 })

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -63,3 +63,31 @@ test_that("rbind_nmatrix works", {
     expect_error(rbind_3nmatrix(x1, x2, t(x3)))
 
 })
+
+test_that("formX_intcovar works", {
+
+    set.seed(20151130)
+    n <- 100
+    addcovar <- cbind(rep(1,n), sample(0:1, n, replace=TRUE))
+
+    # create a prob matrix
+    prob <- matrix(abs(rnorm(n*3)), ncol=3)
+    prob <- (prob/rowSums(prob))[,-1]
+
+    intcovar <- addcovar[,2,drop=FALSE]
+
+    X <- formX_intcovar(prob, addcovar, intcovar)
+    expected <- cbind(addcovar, prob, prob*as.numeric(intcovar))
+    expect_equal(X, expected)
+
+    # no interactive covariates
+    expect_equal(formX_intcovar(prob, addcovar, matrix(ncol=0, nrow=n)), cbind(addcovar, prob))
+
+    # neither interactive nor additive covariates
+    expect_equal(formX_intcovar(prob, matrix(ncol=0, nrow=n), matrix(ncol=0, nrow=n)), prob)
+
+    # mismatch in rows
+    expect_error(formX_intcovar(prob, addcovar[-n,], intcovar))
+    expect_error(formX_intcovar(prob, addcovar, intcovar[-1,]))
+
+})

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -100,3 +100,36 @@ test_that("formX_intcovar works", {
     expect_equal(X, expected)
 
 })
+
+test_that("weighted_matrix works", {
+
+    set.seed(20151201)
+    n <- 100
+    p <- 10
+    X <- matrix(rnorm(n*p), ncol=p)
+    w <- runif(n, 1, 4)
+
+    result <- weighted_matrix(X, w)
+
+    expect_equal(result, X*w)
+    for(i in 1:p) expect_equal(result[,i], X[,i]*w)
+
+})
+
+test_that("weighted_3darray works", {
+
+    set.seed(20151201)
+    n <- 100
+    p <- 3
+    q <- 8
+    X <- array(rnorm(n*p*q), dim=c(n, p, q))
+    w <- runif(n, 1, 4)
+
+    result <- weighted_3darray(X, w)
+
+    expect_equal(result, X*w)
+    for(i in 1:p)
+        for(j in 1:q)
+            expect_equal(result[,i,j], X[,i,j]*w)
+
+})

--- a/tests/testthat/test-scanhk.R
+++ b/tests/testthat/test-scanhk.R
@@ -16,10 +16,11 @@ test_that("genome scan by Haley-Knott same as R/qtl", {
     # inputs for R/qtl2
     pr <- qtl2geno::calc_genoprob(hyper2, step=1)[[1]][,2,,drop=FALSE]
     y <- hyper2$pheno[,1]
+    n <- length(y)
 
     # scan
-    rss1 <- scan_hk_onechr(pr, as.matrix(y), as.matrix(rep(1, length(y))))
-    lod1 <- length(y)/2 * (log10(sum((y-mean(y))^2)) - log10(rss1))
+    rss1 <- scan_hk_onechr(pr, as.matrix(y), as.matrix(rep(1, n)))
+    lod1 <- n/2 * (log10(sum((y-mean(y))^2)) - log10(rss1))
     lod1 <- as.numeric(lod1)
 
     # as expected?
@@ -27,17 +28,35 @@ test_that("genome scan by Haley-Knott same as R/qtl", {
 
     ###
     # try it by centering first
-    intercept <- cbind(rep(1, qtl2geno::n_ind(hyper2)))
-    pr <- calc_resid_linreg_3d(intercept, pr)
-    y <- calc_resid_linreg(intercept, as.matrix(y))
+    intercept <- cbind(rep(1, n))
+    pr_r <- calc_resid_linreg_3d(intercept, pr)
+    y_r <- calc_resid_linreg(intercept, as.matrix(y))
 
     # scan
-    rss2 <- scan_hk_onechr_nocovar(pr, y)
-    lod2 <- length(y)/2 * (log10(sum(y^2)) - log10(rss2))
+    rss2 <- scan_hk_onechr_nocovar(pr_r, y_r)
+    lod2 <- n/2 * (log10(sum(y_r^2)) - log10(rss2))
     lod2 <- as.numeric(lod2)
 
     # as expected?
     expect_equal(lod0, lod2)
     expect_equal(rss1, rss2)
+
+    ##############################
+    # weighted scan
+    w <- runif(n, 1, 3)
+    outw <- scanone(hyper, method="hk", weights=w)
+    lodw0 <- outw[,3]
+
+    rssw1 <- scan_hk_onechr_weighted(pr, as.matrix(y), as.matrix(rep(1, n)), sqrt(w))
+    lodw1 <- n/2 * (log10(sum(lm(y ~ 1, weights=w)$resid^2*w)) - log10(rssw1))
+    lodw1 <- as.numeric(lodw1)
+
+    rssw2 <- scan_hk_onechr(pr*sqrt(w), as.matrix(y)*sqrt(w), as.matrix(rep(1, n))*sqrt(w))
+    lodw2 <- n/2 * (log10(sum(lm(y ~ 1, weights=w)$resid^2*w)) - log10(rssw2))
+    lodw2 <- as.numeric(lodw2)
+
+    # as expected?
+    expect_equal(lodw0, lodw1)
+    expect_equal(lodw1, lodw2)
 
 })

--- a/tests/testthat/test-scanhk.R
+++ b/tests/testthat/test-scanhk.R
@@ -11,22 +11,33 @@ test_that("genome scan by Haley-Knott same as R/qtl", {
     # scan by R/qtl
     hyper <- calc.genoprob(hyper, step=1)
     out <- scanone(hyper, method="hk")
+    lod0 <- out[,3]
 
     # inputs for R/qtl2
     pr <- qtl2geno::calc_genoprob(hyper2, step=1)[[1]][,2,,drop=FALSE]
     y <- hyper2$pheno[,1]
 
-    # center
+    # scan
+    rss1 <- scan_hk_onechr(pr, as.matrix(y), as.matrix(rep(1, length(y))))
+    lod1 <- length(y)/2 * (log10(sum((y-mean(y))^2)) - log10(rss1))
+    lod1 <- as.numeric(lod1)
+
+    # as expected?
+    expect_equal(lod0, lod1)
+
+    ###
+    # try it by centering first
     intercept <- cbind(rep(1, qtl2geno::n_ind(hyper2)))
     pr <- calc_resid_linreg_3d(intercept, pr)
     y <- calc_resid_linreg(intercept, as.matrix(y))
 
     # scan
-    rss <- scan_hk_onechr_nocovar(pr, y)
-    lod <- qtl2geno::n_ind(hyper2)/2 * (log10(sum(y^2)) - log10(rss))
-    lod <- as.numeric(lod)
+    rss2 <- scan_hk_onechr_nocovar(pr, y)
+    lod2 <- length(y)/2 * (log10(sum(y^2)) - log10(rss2))
+    lod2 <- as.numeric(lod2)
 
     # as expected?
-    expect_equal(out[,3], lod)
+    expect_equal(lod0, lod2)
+    expect_equal(rss1, rss2)
 
 })

--- a/tests/testthat/test-scanhk.R
+++ b/tests/testthat/test-scanhk.R
@@ -3,7 +3,7 @@ library(qtl)
 
 test_that("genome scan by Haley-Knott same as R/qtl", {
 
-    # data for chr 4
+    # data for chr 6
     data(hyper)
     hyper <- hyper[6,]
     hyper2 <- qtl2geno::convert2cross2(hyper)
@@ -54,6 +54,67 @@ test_that("genome scan by Haley-Knott same as R/qtl", {
     rssw2 <- scan_hk_onechr(pr*sqrt(w), as.matrix(y)*sqrt(w), as.matrix(rep(1, n))*sqrt(w))
     lodw2 <- n/2 * (log10(sum(lm(y ~ 1, weights=w)$resid^2*w)) - log10(rssw2))
     lodw2 <- as.numeric(lodw2)
+
+    # as expected?
+    expect_equal(lodw0, lodw1)
+    expect_equal(lodw1, lodw2)
+
+})
+
+test_that("genome scan by Haley-Knott with multiple phenotypes is same as R/qtl", {
+
+    # data for chr 6
+    data(hyper)
+    hyper <- hyper[6,]
+    hyper2 <- qtl2geno::convert2cross2(hyper)
+    n_phe <- 200
+    hyper$pheno <- cbind(permute_nvector(n_phe, hyper$pheno[,1]),
+                         hyper$pheno[,2,drop=FALSE]) # sex column left at the end
+
+    # scan by R/qtl
+    hyper <- calc.genoprob(hyper, step=1)
+    out <- scanone(hyper, method="hk", pheno.col=1:n_phe)
+    lod0 <- t(out[,-(1:2)])
+    dimnames(lod0) <- NULL
+
+    # inputs for R/qtl2
+    pr <- qtl2geno::calc_genoprob(hyper2, step=1)[[1]][,2,,drop=FALSE]
+    y <- as.matrix(hyper$pheno[,1:n_phe])
+    n <- nrow(y)
+
+    # scan
+    rss1 <- scan_hk_onechr(pr, y, as.matrix(rep(1, n)))
+    lod1 <- n/2 * (log10(colSums((y-colMeans(y))^2)) - log10(rss1))
+
+    # as expected?
+    expect_equal(lod0, lod1)
+
+    ###
+    # try it by centering first
+    intercept <- cbind(rep(1, n))
+    pr_r <- calc_resid_linreg_3d(intercept, pr)
+    y_r <- calc_resid_linreg(intercept, as.matrix(y))
+
+    # scan
+    rss2 <- scan_hk_onechr_nocovar(pr_r, y_r)
+    lod2 <- n/2 * (log10(colSums(y_r^2)) - log10(rss2))
+
+    # as expected?
+    expect_equal(lod0, lod2)
+    expect_equal(rss1, rss2)
+
+    ##############################
+    # weighted scan
+    w <- runif(n, 1, 3)
+    outw <- scanone(hyper, method="hk", weights=w, phe=1:n_phe)
+    lodw0 <- t(outw[,-(1:2)])
+    dimnames(lodw0) <- NULL
+
+    rssw1 <- scan_hk_onechr_weighted(pr, y, as.matrix(rep(1, n)), sqrt(w))
+    lodw1 <- n/2 * (log10(colSums(lm(y~1, weights=w)$resid^2*w)) - log10(rssw1))
+
+    rssw2 <- scan_hk_onechr(pr*sqrt(w), y*sqrt(w), as.matrix(rep(1, n))*sqrt(w))
+    lodw2 <- n/2 * (log10(colSums(lm(y~1, weights=w)$resid^2*w)) - log10(rssw2))
 
     # as expected?
     expect_equal(lodw0, lodw1)

--- a/tests/testthat/test-scanhk.R
+++ b/tests/testthat/test-scanhk.R
@@ -18,11 +18,11 @@ test_that("genome scan by Haley-Knott same as R/qtl", {
 
     # center
     intercept <- cbind(rep(1, qtl2geno::n_ind(hyper2)))
-    pr <- qtl2scan:::calc_resid_linreg_3d(intercept, pr)
-    y <- qtl2scan:::calc_resid_linreg(intercept, as.matrix(y))
+    pr <- calc_resid_linreg_3d(intercept, pr)
+    y <- calc_resid_linreg(intercept, as.matrix(y))
 
     # scan
-    rss <- qtl2scan:::scan_hk_onechr_nocovar(pr, y)
+    rss <- scan_hk_onechr_nocovar(pr, y)
     lod <- qtl2geno::n_ind(hyper2)/2 * (log10(sum(y^2)) - log10(rss))
     lod <- as.numeric(lod)
 


### PR DESCRIPTION
Added
- `formX_intcovar()` for forming design matrix from additive covariates, genotype probabilities, and interactive covariates
- `scan_hk_onechr()` for single-QTL scan of a chromosome with additive covariates
- `scan_hk_onechr_weighted()` &mdash; same as `scan_hk_onechr()` but with fixed weights on the individuals
