### PR TITLE
Scan of single chr by Haley-Knott regr, with interactive covariates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2scan
-Version: 0.3-7
+Version: 0.3-8
 Date: 2015-12-01
 Title: Genome Scans for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Maintainer: Karl W Broman <kbroman@biostat.wisc.edu>
 Depends:
     R (>= 3.1.0)
 Imports:
-    Rcpp (>= 0.11.2)
+    Rcpp (>= 0.12.1)
 Suggests:
     knitr,
     rmarkdown,

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -109,8 +109,8 @@ find_lin_indep_cols <- function(mat, tol = 1e-12) {
     .Call('qtl2scan_find_lin_indep_cols', PACKAGE = 'qtl2scan', mat, tol)
 }
 
-formX_intcovar <- function(probs, addcovar, intcovar) {
-    .Call('qtl2scan_formX_intcovar', PACKAGE = 'qtl2scan', probs, addcovar, intcovar)
+formX_intcovar <- function(probs, addcovar, intcovar, position) {
+    .Call('qtl2scan_formX_intcovar', PACKAGE = 'qtl2scan', probs, addcovar, intcovar, position)
 }
 
 expand_genoprobs_intcovar <- function(probs, intcovar) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -161,3 +161,7 @@ scan_hk_onechr_weighted <- function(genoprobs, pheno, addcovar, weights, tol = 1
     .Call('qtl2scan_scan_hk_onechr_weighted', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, weights, tol)
 }
 
+scan_hk_onechr_intcovar_highmem <- function(genoprobs, pheno, addcovar, intcovar, tol = 1e-12) {
+    .Call('qtl2scan_scan_hk_onechr_intcovar_highmem', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, intcovar, tol)
+}
+

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -165,3 +165,7 @@ scan_hk_onechr_intcovar_highmem <- function(genoprobs, pheno, addcovar, intcovar
     .Call('qtl2scan_scan_hk_onechr_intcovar_highmem', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, intcovar, tol)
 }
 
+scan_hk_onechr_intcovar_weighted_highmem <- function(genoprobs, pheno, addcovar, intcovar, weights, tol = 1e-12) {
+    .Call('qtl2scan_scan_hk_onechr_intcovar_weighted_highmem', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, intcovar, weights, tol)
+}
+

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -169,3 +169,11 @@ scan_hk_onechr_intcovar_weighted_highmem <- function(genoprobs, pheno, addcovar,
     .Call('qtl2scan_scan_hk_onechr_intcovar_weighted_highmem', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, intcovar, weights, tol)
 }
 
+scan_hk_onechr_intcovar_lowmem <- function(genoprobs, pheno, addcovar, intcovar, tol = 1e-12) {
+    .Call('qtl2scan_scan_hk_onechr_intcovar_lowmem', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, intcovar, tol)
+}
+
+scan_hk_onechr_intcovar_weighted_lowmem <- function(genoprobs, pheno, addcovar, intcovar, weights, tol = 1e-12) {
+    .Call('qtl2scan_scan_hk_onechr_intcovar_weighted_lowmem', PACKAGE = 'qtl2scan', genoprobs, pheno, addcovar, intcovar, weights, tol)
+}
+

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -113,6 +113,10 @@ formX_intcovar <- function(probs, addcovar, intcovar) {
     .Call('qtl2scan_formX_intcovar', PACKAGE = 'qtl2scan', probs, addcovar, intcovar)
 }
 
+expand_genoprobs_intcovar <- function(probs, intcovar) {
+    .Call('qtl2scan_expand_genoprobs_intcovar', PACKAGE = 'qtl2scan', probs, intcovar)
+}
+
 weighted_matrix <- function(mat, weights) {
     .Call('qtl2scan_weighted_matrix', PACKAGE = 'qtl2scan', mat, weights)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -364,6 +364,18 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// expand_genoprobs_intcovar
+NumericVector expand_genoprobs_intcovar(const NumericVector& probs, const NumericMatrix& intcovar);
+RcppExport SEXP qtl2scan_expand_genoprobs_intcovar(SEXP probsSEXP, SEXP intcovarSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericVector& >::type probs(probsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type intcovar(intcovarSEXP);
+    __result = Rcpp::wrap(expand_genoprobs_intcovar(probs, intcovar));
+    return __result;
+END_RCPP
+}
 // weighted_matrix
 NumericMatrix weighted_matrix(const NumericMatrix& mat, const NumericVector& weights);
 RcppExport SEXP qtl2scan_weighted_matrix(SEXP matSEXP, SEXP weightsSEXP) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -534,3 +534,19 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// scan_hk_onechr_intcovar_weighted_highmem
+NumericMatrix scan_hk_onechr_intcovar_weighted_highmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const double tol);
+RcppExport SEXP qtl2scan_scan_hk_onechr_intcovar_weighted_highmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP tolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericVector& >::type genoprobs(genoprobsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type pheno(phenoSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type intcovar(intcovarSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
+    __result = Rcpp::wrap(scan_hk_onechr_intcovar_weighted_highmem(genoprobs, pheno, addcovar, intcovar, weights, tol));
+    return __result;
+END_RCPP
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -352,15 +352,16 @@ BEGIN_RCPP
 END_RCPP
 }
 // formX_intcovar
-NumericMatrix formX_intcovar(const NumericMatrix& probs, const NumericMatrix& addcovar, const NumericMatrix& intcovar);
-RcppExport SEXP qtl2scan_formX_intcovar(SEXP probsSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP) {
+NumericMatrix formX_intcovar(const NumericVector& probs, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const int position);
+RcppExport SEXP qtl2scan_formX_intcovar(SEXP probsSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP positionSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
     Rcpp::RNGScope __rngScope;
-    Rcpp::traits::input_parameter< const NumericMatrix& >::type probs(probsSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type probs(probsSEXP);
     Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
     Rcpp::traits::input_parameter< const NumericMatrix& >::type intcovar(intcovarSEXP);
-    __result = Rcpp::wrap(formX_intcovar(probs, addcovar, intcovar));
+    Rcpp::traits::input_parameter< const int >::type position(positionSEXP);
+    __result = Rcpp::wrap(formX_intcovar(probs, addcovar, intcovar, position));
     return __result;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -550,3 +550,34 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// scan_hk_onechr_intcovar_lowmem
+NumericMatrix scan_hk_onechr_intcovar_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const double tol);
+RcppExport SEXP qtl2scan_scan_hk_onechr_intcovar_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP tolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericVector& >::type genoprobs(genoprobsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type pheno(phenoSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type intcovar(intcovarSEXP);
+    Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
+    __result = Rcpp::wrap(scan_hk_onechr_intcovar_lowmem(genoprobs, pheno, addcovar, intcovar, tol));
+    return __result;
+END_RCPP
+}
+// scan_hk_onechr_intcovar_weighted_lowmem
+NumericMatrix scan_hk_onechr_intcovar_weighted_lowmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const NumericVector& weights, const double tol);
+RcppExport SEXP qtl2scan_scan_hk_onechr_intcovar_weighted_lowmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP weightsSEXP, SEXP tolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericVector& >::type genoprobs(genoprobsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type pheno(phenoSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type intcovar(intcovarSEXP);
+    Rcpp::traits::input_parameter< const NumericVector& >::type weights(weightsSEXP);
+    Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
+    __result = Rcpp::wrap(scan_hk_onechr_intcovar_weighted_lowmem(genoprobs, pheno, addcovar, intcovar, weights, tol));
+    return __result;
+END_RCPP
+}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -519,3 +519,18 @@ BEGIN_RCPP
     return __result;
 END_RCPP
 }
+// scan_hk_onechr_intcovar_highmem
+NumericMatrix scan_hk_onechr_intcovar_highmem(const NumericVector& genoprobs, const NumericMatrix& pheno, const NumericMatrix& addcovar, const NumericMatrix& intcovar, const double tol);
+RcppExport SEXP qtl2scan_scan_hk_onechr_intcovar_highmem(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP intcovarSEXP, SEXP tolSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< const NumericVector& >::type genoprobs(genoprobsSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type pheno(phenoSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
+    Rcpp::traits::input_parameter< const NumericMatrix& >::type intcovar(intcovarSEXP);
+    Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
+    __result = Rcpp::wrap(scan_hk_onechr_intcovar_highmem(genoprobs, pheno, addcovar, intcovar, tol));
+    return __result;
+END_RCPP
+}

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -53,4 +53,8 @@ Rcpp::NumericMatrix weighted_matrix(const Rcpp::NumericMatrix& mat,
 Rcpp::NumericVector weighted_3darray(const Rcpp::NumericVector& array,
                                      const Rcpp::NumericVector& weights);
 
+// expand genotype probabilities with intcovar
+Rcpp::NumericVector expand_genoprobs_intcovar(const Rcpp::NumericVector& probs, // 3d array ind x prob x pos
+                                              const Rcpp::NumericMatrix& intcovar);
+
 #endif // MATRIX_H

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -41,13 +41,14 @@ Rcpp::IntegerVector find_lin_indep_cols(const Rcpp::NumericMatrix& mat,
                                         const double tol);
 
 // form X matrix with intcovar
-Rcpp::NumericMatrix formX_intcovar(const Rcpp::NumericMatrix& probs,
+Rcpp::NumericMatrix formX_intcovar(const Rcpp::NumericVector& probs,
                                    const Rcpp::NumericMatrix& addcovar,
-                                   const Rcpp::NumericMatrix& intcovar);
+                                   const Rcpp::NumericMatrix& intcovar,
+                                   const int position);
 
 // multiply each column of a matrix by a set of weights
 Rcpp::NumericMatrix weighted_matrix(const Rcpp::NumericMatrix& mat,
-                              const Rcpp::NumericVector& weights);
+                                    const Rcpp::NumericVector& weights);
 
 // multiply each element of a vector by the corresponding weight
 Rcpp::NumericVector weighted_3darray(const Rcpp::NumericVector& array,

--- a/src/scan_hk.cpp
+++ b/src/scan_hk.cpp
@@ -68,10 +68,10 @@ NumericMatrix scan_hk_onechr(const NumericVector& genoprobs, const NumericMatrix
 
     NumericMatrix result(n_phe, n_pos);
 
-    NumericVector genoprob_resid = calc_resid_linreg_3d(addcovar, genoprobs, tol);
+    NumericVector genoprobs_resid = calc_resid_linreg_3d(addcovar, genoprobs, tol);
     NumericMatrix pheno_resid = calc_resid_linreg(addcovar, pheno, tol);
 
-    return scan_hk_onechr_nocovar(genoprob_resid, pheno_resid, tol);
+    return scan_hk_onechr_nocovar(genoprobs_resid, pheno_resid, tol);
 }
 
 // Scan a single chromosome with additive covariates and weights

--- a/src/scan_hk.cpp
+++ b/src/scan_hk.cpp
@@ -66,8 +66,6 @@ NumericMatrix scan_hk_onechr(const NumericVector& genoprobs, const NumericMatrix
     if(n_ind != addcovar.rows())
         throw std::range_error("nrow(pheno) != nrow(addcovar)");
 
-    NumericMatrix result(n_phe, n_pos);
-
     NumericVector genoprobs_resid = calc_resid_linreg_3d(addcovar, genoprobs, tol);
     NumericMatrix pheno_resid = calc_resid_linreg(addcovar, pheno, tol);
 
@@ -100,9 +98,6 @@ NumericMatrix scan_hk_onechr_weighted(const NumericVector& genoprobs, const Nume
     if(n_ind != weights.size())
         throw std::range_error("nrow(pheno) != length(weights)");
 
-    // to contain the result
-    NumericMatrix result(n_phe, n_pos);
-
     // multiply everything by the (square root) of the weights
     // (weights should ALREADY be the square-root of the real weights)
     NumericMatrix addcovar_wt = weighted_matrix(addcovar, weights);
@@ -115,4 +110,45 @@ NumericMatrix scan_hk_onechr_weighted(const NumericVector& genoprobs, const Nume
 
     // now the scan
     return scan_hk_onechr_nocovar(genoprobs_wt, pheno_wt, tol);
+}
+
+// Scan a single chromosome with interactive covariates
+// this version should be fast but requires more memory
+// (since we first expand the genotype probabilities to probs x intcovar)
+//
+// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// pheno     = matrix of numeric phenotypes (individuals x phenotypes)
+//             (no missing data allowed)
+// addcovar  = additive covariates (an intercept, at least)
+// intcovar  = interactive covariates (should also be included in addcovar)
+//
+// output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
+//
+// [[Rcpp::export]]
+NumericMatrix scan_hk_onechr_intcovar_highmem(const NumericVector& genoprobs,
+                                              const NumericMatrix& pheno,
+                                              const NumericMatrix& addcovar,
+                                              const NumericMatrix& intcovar,
+                                              const double tol=1e-12)
+{
+    const unsigned int n_ind = pheno.rows();
+    const unsigned int n_phe = pheno.cols();
+    const Dimension d = genoprobs.attr("dim");
+    const unsigned int n_pos = d[2];
+    if(n_ind != d[0])
+        throw std::range_error("nrow(pheno) != nrow(genoprobs)");
+    if(n_ind != addcovar.rows())
+        throw std::range_error("nrow(pheno) != nrow(addcovar)");
+    if(n_ind != intcovar.rows())
+        throw std::range_error("nrow(pheno) != nrow(intcovar)");
+
+    // expand genotype probabilities to include geno x interactive covariate
+    NumericVector genoprobs_rev = expand_genoprobs_intcovar(genoprobs, intcovar);
+
+    // regress out the additive covariates
+    genoprobs_rev = calc_resid_linreg_3d(addcovar, genoprobs_rev, tol);
+    NumericMatrix pheno_rev = calc_resid_linreg(addcovar, pheno, tol);
+
+    // genotype can
+    return scan_hk_onechr_nocovar(genoprobs_rev, pheno_rev, tol);
 }

--- a/src/scan_hk.cpp
+++ b/src/scan_hk.cpp
@@ -58,9 +58,7 @@ NumericMatrix scan_hk_onechr(const NumericVector& genoprobs, const NumericMatrix
                              const NumericMatrix& addcovar, const double tol=1e-12)
 {
     const unsigned int n_ind = pheno.rows();
-    const unsigned int n_phe = pheno.cols();
     const Dimension d = genoprobs.attr("dim");
-    const unsigned int n_pos = d[2];
     if(n_ind != d[0])
         throw std::range_error("nrow(pheno) != nrow(genoprobs)");
     if(n_ind != addcovar.rows())
@@ -88,9 +86,7 @@ NumericMatrix scan_hk_onechr_weighted(const NumericVector& genoprobs, const Nume
                                       const double tol=1e-12)
 {
     const unsigned int n_ind = pheno.rows();
-    const unsigned int n_phe = pheno.cols();
     const Dimension d = genoprobs.attr("dim");
-    const unsigned int n_pos = d[2];
     if(n_ind != d[0])
         throw std::range_error("nrow(pheno) != nrow(genoprobs)");
     if(n_ind != addcovar.rows())
@@ -132,9 +128,7 @@ NumericMatrix scan_hk_onechr_intcovar_highmem(const NumericVector& genoprobs,
                                               const double tol=1e-12)
 {
     const unsigned int n_ind = pheno.rows();
-    const unsigned int n_phe = pheno.cols();
     const Dimension d = genoprobs.attr("dim");
-    const unsigned int n_pos = d[2];
     if(n_ind != d[0])
         throw std::range_error("nrow(pheno) != nrow(genoprobs)");
     if(n_ind != addcovar.rows())

--- a/src/scan_hk.h
+++ b/src/scan_hk.h
@@ -62,4 +62,24 @@ Rcpp::NumericMatrix scan_hk_onechr_intcovar_highmem(const Rcpp::NumericVector& g
                                                     const Rcpp::NumericMatrix& intcovar,
                                                     const double);
 
+// Scan a single chromosome with interactive covariates
+// this version should be fast but requires more memory
+// (since we first expand the genotype probabilities to probs x intcovar)
+// and this one allows weights for the individuals (the same for all phenotypes)
+//
+// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// pheno     = matrix of numeric phenotypes (individuals x phenotypes)
+//             (no missing data allowed)
+// addcovar  = additive covariates (an intercept, at least)
+// intcovar  = interactive covariates (should also be included in addcovar)
+//
+//
+// output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
+Rcpp::NumericMatrix scan_hk_onechr_intcovar_weighted_highmem(const Rcpp::NumericVector& genoprobs,
+                                                             const Rcpp::NumericMatrix& pheno,
+                                                             const Rcpp::NumericMatrix& addcovar,
+                                                             const Rcpp::NumericMatrix& intcovar,
+                                                             const Rcpp::NumericVector& weights,
+                                                             const double tol);
+
 #endif // SCAN_HK_H

--- a/src/scan_hk.h
+++ b/src/scan_hk.h
@@ -45,4 +45,21 @@ Rcpp::NumericMatrix scan_hk_onechr_weighted(const Rcpp::NumericVector& genoprobs
                                             const Rcpp::NumericVector& weights,
                                             const double tol);
 
+// Scan a single chromosome with interactive covariates
+// this version should be fast but requires more memory
+// (since we first expand the genotype probabilities to probs x intcovar)
+//
+// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// pheno     = matrix of numeric phenotypes (individuals x phenotypes)
+//             (no missing data allowed)
+// addcovar  = additive covariates (an intercept, at least)
+// intcovar  = interactive covariates (should also be included in addcovar)
+//
+// output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
+Rcpp::NumericMatrix scan_hk_onechr_intcovar_highmem(const Rcpp::NumericVector& genoprobs,
+                                                    const Rcpp::NumericMatrix& pheno,
+                                                    const Rcpp::NumericMatrix& addcovar,
+                                                    const Rcpp::NumericMatrix& intcovar,
+                                                    const double);
+
 #endif // SCAN_HK_H

--- a/src/scan_hk.h
+++ b/src/scan_hk.h
@@ -72,7 +72,7 @@ Rcpp::NumericMatrix scan_hk_onechr_intcovar_highmem(const Rcpp::NumericVector& g
 //             (no missing data allowed)
 // addcovar  = additive covariates (an intercept, at least)
 // intcovar  = interactive covariates (should also be included in addcovar)
-//
+// weights   = vector of weights (really the SQUARE ROOT of the weights)
 //
 // output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
 Rcpp::NumericMatrix scan_hk_onechr_intcovar_weighted_highmem(const Rcpp::NumericVector& genoprobs,
@@ -81,5 +81,42 @@ Rcpp::NumericMatrix scan_hk_onechr_intcovar_weighted_highmem(const Rcpp::Numeric
                                                              const Rcpp::NumericMatrix& intcovar,
                                                              const Rcpp::NumericVector& weights,
                                                              const double tol);
+
+// Scan a single chromosome with interactive covariates
+// this version uses less memory but will be slower
+// (since we need to work with each position, one at a time)
+//
+// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// pheno     = matrix of numeric phenotypes (individuals x phenotypes)
+//             (no missing data allowed)
+// addcovar  = additive covariates (an intercept, at least)
+// intcovar  = interactive covariates (should also be included in addcovar)
+//
+// output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
+Rcpp::NumericMatrix scan_hk_onechr_intcovar_lowmem(const Rcpp::NumericVector& genoprobs,
+                                                   const Rcpp::NumericMatrix& pheno,
+                                                   const Rcpp::NumericMatrix& addcovar,
+                                                   const Rcpp::NumericMatrix& intcovar,
+                                                   const double tol);
+
+// Scan a single chromosome with interactive covariates
+// this version uses less memory but will be slower
+// (since we need to work with each position, one at a time)
+// and this one allows weights for the individuals (the same for all phenotypes)
+//
+// genoprobs = 3d array of genotype probabilities (individuals x genotypes x positions)
+// pheno     = matrix of numeric phenotypes (individuals x phenotypes)
+//             (no missing data allowed)
+// addcovar  = additive covariates (an intercept, at least)
+// intcovar  = interactive covariates (should also be included in addcovar)
+// weights   = vector of weights (really the SQUARE ROOT of the weights)
+//
+// output    = matrix of residual sums of squares (RSS) (phenotypes x positions)
+Rcpp::NumericMatrix scan_hk_onechr_intcovar_weighted_lowmem(const Rcpp::NumericVector& genoprobs,
+                                                            const Rcpp::NumericMatrix& pheno,
+                                                            const Rcpp::NumericMatrix& addcovar,
+                                                            const Rcpp::NumericMatrix& intcovar,
+                                                            const Rcpp::NumericVector& weights,
+                                                            const double tol);
 
 #endif // SCAN_HK_H

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -101,6 +101,36 @@ test_that("formX_intcovar works", {
 
 })
 
+test_that("expand_genoprobs_intcovar works", {
+
+    set.seed(20151201)
+    library(qtl)
+    data(fake.f2)
+    pr <- aperm(calc.genoprob(fake.f2["2",], step=5)$geno[["2"]]$prob[,,-1],
+                c(1,3,2))
+    dimnames(pr) <- NULL
+    rownames(pr) <- paste(1:nind(fake.f2))
+
+    intcovar <- cbind(sample(0:1, nrow(pr), replace=TRUE),
+                      sample(0:1, nrow(pr), replace=TRUE))
+
+    result <- expand_genoprobs_intcovar(pr, intcovar)
+
+    expect_equal(dim(result), dim(pr)*c(1,ncol(intcovar)+1,1))
+    expect_equal(result[,1:2,] , pr)
+    expect_equal(result[,3:4,], pr*intcovar[,1])
+    expect_equal(result[,5:6,], pr*intcovar[,2])
+
+    # single interactive covariate
+    result2 <- expand_genoprobs_intcovar(pr, intcovar[,1,drop=FALSE])
+
+    expect_equal(dim(result2), dim(pr)*c(1,2,1))
+    expect_equal(result2[,1:2,] , pr)
+    expect_equal(result2[,3:4,], pr*intcovar[,1])
+
+})
+
+
 test_that("weighted_matrix works", {
 
     set.seed(20151201)

--- a/tests/testthat/test-matrix.R
+++ b/tests/testthat/test-matrix.R
@@ -67,36 +67,43 @@ test_that("rbind_nmatrix works", {
 test_that("formX_intcovar works", {
 
     set.seed(20151130)
-    n <- 100
-    addcovar <- cbind(rep(1,n), sample(0:1, n, replace=TRUE))
 
     # create a prob matrix
-    prob <- matrix(abs(rnorm(n*3)), ncol=3)
-    prob <- (prob/rowSums(prob))[,-1]
+    library(qtl)
+    data(fake.f2)
+    prob <- aperm(calc.genoprob(fake.f2["2",], step=5)$geno[["2"]]$prob[,,-1],
+                  c(1,3,2))
+    dimnames(prob) <- NULL
 
+    n <- nind(fake.f2)
+    addcovar <- cbind(rep(1,n), sample(0:1, n, replace=TRUE))
     intcovar <- addcovar[,2,drop=FALSE]
 
-    X <- formX_intcovar(prob, addcovar, intcovar)
-    expected <- cbind(addcovar, prob, prob*intcovar[,1]) # the [,1] makes intcovar an ordinary vector
+    X <- formX_intcovar(prob, addcovar, intcovar, 0)
+    expected <- cbind(addcovar, prob[,,1], prob[,,1]*intcovar[,1]) # the [,1] makes intcovar an ordinary vector
+    expect_equal(X, expected)
+
+    X <- formX_intcovar(prob, addcovar, intcovar, 5)
+    expected <- cbind(addcovar, prob[,,6], prob[,,6]*intcovar[,1]) # the [,1] makes intcovar an ordinary vector
     expect_equal(X, expected)
 
     # no interactive covariates
-    expect_equal(formX_intcovar(prob, addcovar, matrix(ncol=0, nrow=n)), cbind(addcovar, prob))
+    expect_equal(formX_intcovar(prob, addcovar, matrix(ncol=0, nrow=n), 2), cbind(addcovar, prob[,,3]))
 
     # neither interactive nor additive covariates
-    expect_equal(formX_intcovar(prob, matrix(ncol=0, nrow=n), matrix(ncol=0, nrow=n)), prob)
+    expect_equal(formX_intcovar(prob, matrix(ncol=0, nrow=n), matrix(ncol=0, nrow=n), 3), prob[,,4])
 
     # mismatch in rows
-    expect_error(formX_intcovar(prob, addcovar[-n,], intcovar))
-    expect_error(formX_intcovar(prob, addcovar, intcovar[-1,]))
+    expect_error(formX_intcovar(prob, addcovar[-n,], intcovar, 0))
+    expect_error(formX_intcovar(prob, addcovar, intcovar[-1,], 2))
 
     # two interactive covariates
     addcovar <- cbind(addcovar, sample(0:1, n, replace=TRUE))
 
     intcovar <- addcovar[,-1]
 
-    X <- formX_intcovar(prob, addcovar, intcovar)
-    expected <- cbind(addcovar, prob, prob*intcovar[,1], prob*intcovar[,2])
+    X <- formX_intcovar(prob, addcovar, intcovar, 4)
+    expected <- cbind(addcovar, prob[,,5], prob[,,5]*intcovar[,1], prob[,,5]*intcovar[,2])
     expect_equal(X, expected)
 
 })

--- a/tests/testthat/test-scanhk.R
+++ b/tests/testthat/test-scanhk.R
@@ -286,6 +286,8 @@ test_that("genome scan by Haley-Knott works with interactive covariates", {
 
     # scan
     rss1 <- scan_hk_onechr_intcovar_highmem(pr, as.matrix(y), cbind(1, x), as.matrix(x))
+    rss1_lm <- scan_hk_onechr_intcovar_lowmem(pr, as.matrix(y), cbind(1, x), as.matrix(x))
+    expect_equal(rss1, rss1_lm)
     lod1 <- n/2 * (log10(sum(lm(y~x)$resid^2)) - log10(rss1))
     lod1 <- as.numeric(lod1)
 
@@ -306,6 +308,9 @@ test_that("genome scan by Haley-Knott works with interactive covariates", {
 
     rssw1 <- scan_hk_onechr_intcovar_weighted_highmem(pr, as.matrix(y), cbind(1,x),
                                                       as.matrix(x), sqrt(w))
+    rssw1_lm <- scan_hk_onechr_intcovar_weighted_lowmem(pr, as.matrix(y), cbind(1,x),
+                                                        as.matrix(x), sqrt(w))
+    expect_equal(rssw1, rssw1_lm)
     lodw1 <- n/2 * (log10(sum(lm(y ~ x, weights=w)$resid^2*w)) - log10(rssw1))
     lodw1 <- as.numeric(lodw1)
 
@@ -346,6 +351,8 @@ test_that("genome scan by Haley-Knott with multiple phenotypes and an interactiv
 
     # scan
     rss1 <- scan_hk_onechr_intcovar_highmem(pr, y, cbind(1,x), as.matrix(x))
+    rss1_lm <- scan_hk_onechr_intcovar_lowmem(pr, y, cbind(1,x), as.matrix(x))
+    expect_equal(rss1, rss1_lm)
     lod1 <- n/2 * (log10(colSums(lm(y~x)$resid^2)) - log10(rss1))
 
     # as expected?
@@ -365,6 +372,8 @@ test_that("genome scan by Haley-Knott with multiple phenotypes and an interactiv
     dimnames(lodw0) <- NULL
 
     rssw1 <- scan_hk_onechr_intcovar_weighted_highmem(pr, y, cbind(1,x), as.matrix(x), sqrt(w))
+    rssw1_lm <- scan_hk_onechr_intcovar_weighted_lowmem(pr, y, cbind(1,x), as.matrix(x), sqrt(w))
+    expect_equal(rssw1, rssw1_lm)
     lodw1 <- n/2 * (log10(colSums(lm(y~x, weights=w)$resid^2*w)) - log10(rssw1))
 
     # as expected?

--- a/tests/testthat/test-scanhk.R
+++ b/tests/testthat/test-scanhk.R
@@ -1,7 +1,7 @@
 context("genome scan by Haley-Knott")
 library(qtl)
 
-test_that("genome scan by Haley-Knott same as R/qtl", {
+test_that("genome scan by Haley-Knott works", {
 
     # data for chr 6
     data(hyper)
@@ -41,6 +41,12 @@ test_that("genome scan by Haley-Knott same as R/qtl", {
     expect_equal(lod0, lod2)
     expect_equal(rss1, rss2)
 
+    ###
+    # direct calculation with lm()
+    rss3 <- apply(pr, 3, function(a) sum(lm(y ~ a)$resid^2))
+    names(rss3) <- NULL
+    expect_equal(as.numeric(rss1), rss3)
+
     ##############################
     # weighted scan
     w <- runif(n, 1, 3)
@@ -59,9 +65,15 @@ test_that("genome scan by Haley-Knott same as R/qtl", {
     expect_equal(lodw0, lodw1)
     expect_equal(lodw1, lodw2)
 
+    ###
+    # direct calculation with lm()
+    rssw3 <- apply(pr, 3, function(a) sum(lm(y ~ a, weights=w)$resid^2*w))
+    names(rssw3) <- NULL
+    expect_equal(as.numeric(rssw1), rssw3)
+
 })
 
-test_that("genome scan by Haley-Knott with multiple phenotypes is same as R/qtl", {
+test_that("genome scan by Haley-Knott with multiple phenotypes works", {
 
     # data for chr 6
     data(hyper)
@@ -103,6 +115,12 @@ test_that("genome scan by Haley-Knott with multiple phenotypes is same as R/qtl"
     expect_equal(lod0, lod2)
     expect_equal(rss1, rss2)
 
+    ###
+    # direct calculation with lm()
+    rss3 <- apply(pr, 3, function(a) colSums(lm(y ~ a)$resid^2))
+    dimnames(rss3) <- NULL
+    expect_equal(rss1, rss3)
+
     ##############################
     # weighted scan
     w <- runif(n, 1, 3)
@@ -119,5 +137,11 @@ test_that("genome scan by Haley-Knott with multiple phenotypes is same as R/qtl"
     # as expected?
     expect_equal(lodw0, lodw1)
     expect_equal(lodw1, lodw2)
+
+    ###
+    # direct calculation with lm()
+    rssw3 <- apply(pr, 3, function(a) colSums(lm(y ~ a, weights=w)$resid^2*w))
+    dimnames(rssw3) <- NULL
+    expect_equal(rssw1, rssw3)
 
 })

--- a/tests/testthat/test-scanhk.R
+++ b/tests/testthat/test-scanhk.R
@@ -298,6 +298,26 @@ test_that("genome scan by Haley-Knott works with interactive covariates", {
     names(rss2) <- NULL
     expect_equal(as.numeric(rss1), rss2)
 
+    ##############################
+    # weighted scan
+    w <- runif(n, 1, 3)
+    outw <- scanone(hyper, method="hk", weights=w, addcovar=x, intcovar=x)
+    lodw0 <- outw[,3]
+
+    rssw1 <- scan_hk_onechr_intcovar_weighted_highmem(pr, as.matrix(y), cbind(1,x),
+                                                      as.matrix(x), sqrt(w))
+    lodw1 <- n/2 * (log10(sum(lm(y ~ x, weights=w)$resid^2*w)) - log10(rssw1))
+    lodw1 <- as.numeric(lodw1)
+
+    # as expected?
+    expect_equal(lodw0, lodw1)
+
+    ###
+    # direct calculation with lm()
+    rssw2 <- apply(pr, 3, function(a) sum(lm(y ~ x*a, weights=w)$resid^2*w))
+    names(rssw2) <- NULL
+    expect_equal(as.numeric(rssw1), rssw2)
+
 })
 
 test_that("genome scan by Haley-Knott with multiple phenotypes and an interactive covariate works", {
@@ -336,5 +356,24 @@ test_that("genome scan by Haley-Knott with multiple phenotypes and an interactiv
     rss2 <- apply(pr, 3, function(a) colSums(lm(y ~ x*a)$resid^2))
     dimnames(rss2) <- NULL
     expect_equal(rss1, rss2)
+
+    ##############################
+    # weighted scan
+    w <- runif(n, 1, 3)
+    outw <- scanone(hyper, method="hk", weights=w, addcovar=x, intcovar=x, phe=1:n_phe)
+    lodw0 <- t(outw[,-(1:2)])
+    dimnames(lodw0) <- NULL
+
+    rssw1 <- scan_hk_onechr_intcovar_weighted_highmem(pr, y, cbind(1,x), as.matrix(x), sqrt(w))
+    lodw1 <- n/2 * (log10(colSums(lm(y~x, weights=w)$resid^2*w)) - log10(rssw1))
+
+    # as expected?
+    expect_equal(lodw0, lodw1)
+
+    ###
+    # direct calculation with lm()
+    rssw2 <- apply(pr, 3, function(a) colSums(lm(y ~ x*a, weights=w)$resid^2*w))
+    dimnames(rssw2) <- NULL
+    expect_equal(rssw1, rssw2)
 
 })

--- a/tests/testthat/test-scanhk.R
+++ b/tests/testthat/test-scanhk.R
@@ -75,6 +75,7 @@ test_that("genome scan by Haley-Knott works", {
 
 test_that("genome scan by Haley-Knott with multiple phenotypes works", {
 
+    set.seed(20151201)
     # data for chr 6
     data(hyper)
     hyper <- hyper[6,]
@@ -143,5 +144,120 @@ test_that("genome scan by Haley-Knott with multiple phenotypes works", {
     rssw3 <- apply(pr, 3, function(a) colSums(lm(y ~ a, weights=w)$resid^2*w))
     dimnames(rssw3) <- NULL
     expect_equal(rssw1, rssw3)
+
+})
+
+
+test_that("genome scan by Haley-Knott works with additive covariates", {
+
+    set.seed(20151201)
+
+    # data for chr 6
+    data(hyper)
+    hyper <- hyper[6,]
+    hyper2 <- qtl2geno::convert2cross2(hyper)
+
+    # scan by R/qtl
+    hyper <- calc.genoprob(hyper, step=1)
+    p <- hyper$pheno[,1]; p <- (p-min(p))/max(p)
+    x <- rbinom(nind(hyper), 1, prob=p)
+    out <- scanone(hyper, addcovar=x, method="hk")
+    lod0 <- out[,3]
+
+    # inputs for R/qtl2
+    pr <- qtl2geno::calc_genoprob(hyper2, step=1)[[1]][,2,,drop=FALSE]
+    y <- hyper2$pheno[,1]
+    n <- length(y)
+
+    # scan
+    rss1 <- scan_hk_onechr(pr, as.matrix(y), cbind(1, x))
+    lod1 <- n/2 * (log10(sum(lm(y~x)$resid^2)) - log10(rss1))
+    lod1 <- as.numeric(lod1)
+
+    # as expected?
+    expect_equal(lod0, lod1)
+
+    ###
+    # direct calculation with lm()
+    rss2 <- apply(pr, 3, function(a) sum(lm(y ~ x+a)$resid^2))
+    names(rss2) <- NULL
+    expect_equal(as.numeric(rss1), rss2)
+
+    ##############################
+    # weighted scan
+    w <- runif(n, 1, 3)
+    outw <- scanone(hyper, method="hk", weights=w, addcovar=x)
+    lodw0 <- outw[,3]
+
+    rssw1 <- scan_hk_onechr_weighted(pr, as.matrix(y), cbind(1,x), sqrt(w))
+    lodw1 <- n/2 * (log10(sum(lm(y ~ x, weights=w)$resid^2*w)) - log10(rssw1))
+    lodw1 <- as.numeric(lodw1)
+
+    # as expected?
+    expect_equal(lodw0, lodw1)
+
+    ###
+    # direct calculation with lm()
+    rssw2 <- apply(pr, 3, function(a) sum(lm(y ~ x+a, weights=w)$resid^2*w))
+    names(rssw2) <- NULL
+    expect_equal(as.numeric(rssw1), rssw2)
+
+})
+
+test_that("genome scan by Haley-Knott with multiple phenotypes and an additive covariate works", {
+
+    set.seed(20151201)
+    # data for chr 6
+    data(hyper)
+    hyper <- hyper[6,]
+    hyper2 <- qtl2geno::convert2cross2(hyper)
+    n_phe <- 200
+    hyper$pheno <- cbind(permute_nvector(n_phe, hyper$pheno[,1]),
+                         hyper$pheno[,2,drop=FALSE]) # sex column left at the end
+
+    # scan by R/qtl
+    hyper <- calc.genoprob(hyper, step=1)
+    p <- hyper$pheno[,1]; p <- (p-min(p))/max(p)
+    x <- rbinom(nind(hyper), 1, prob=p)
+    out <- scanone(hyper, method="hk", addcovar=x, pheno.col=1:n_phe)
+    lod0 <- t(out[,-(1:2)])
+    dimnames(lod0) <- NULL
+
+    # inputs for R/qtl2
+    pr <- qtl2geno::calc_genoprob(hyper2, step=1)[[1]][,2,,drop=FALSE]
+    y <- as.matrix(hyper$pheno[,1:n_phe])
+    n <- nrow(y)
+
+    # scan
+    rss1 <- scan_hk_onechr(pr, y, cbind(1,x))
+    lod1 <- n/2 * (log10(colSums(lm(y~x)$resid^2)) - log10(rss1))
+
+    # as expected?
+    expect_equal(lod0, lod1)
+
+    ###
+    # direct calculation with lm()
+    rss2 <- apply(pr, 3, function(a) colSums(lm(y ~ x+a)$resid^2))
+    dimnames(rss2) <- NULL
+    expect_equal(rss1, rss2)
+
+    ##############################
+    # weighted scan
+    w <- runif(n, 1, 3)
+    outw <- scanone(hyper, method="hk", weights=w, addcovar=x, phe=1:n_phe)
+    lodw0 <- t(outw[,-(1:2)])
+    dimnames(lodw0) <- NULL
+
+    rssw1 <- scan_hk_onechr_weighted(pr, y, cbind(1,x), sqrt(w))
+    lodw1 <- n/2 * (log10(colSums(lm(y~x, weights=w)$resid^2*w)) - log10(rssw1))
+
+    # as expected?
+    expect_equal(lodw0, lodw1)
+
+    ###
+    # direct calculation with lm()
+    rssw2 <- apply(pr, 3, function(a) colSums(lm(y ~ x+a, weights=w)$resid^2*w))
+    dimnames(rssw2) <- NULL
+    expect_equal(rssw1, rssw2)
 
 })


### PR DESCRIPTION
Including "low mem" and "high mem" versions; the latter should be faster, but wasn't much in the tests I did. It's still worth exploring.

There are also versions with weights for the individuals.

Revised the `formX_intcovar` function to take the full genotype probabilities plus a position index (rather than a sub-matrix), as this is more convenient for its actual use.
