### PR TITLE
Simplify code related to calculations in parallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.3-11
-Date: 2015-12-05
+Version: 0.3-12
+Date: 2015-12-07
 Title: Genome Scans for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/cluster_util.R
+++ b/R/cluster_util.R
@@ -1,0 +1,47 @@
+# code related to clusters
+# (copy of code also in qtl2geno)
+
+# test if input is a prepared cluster
+is_cluster <-
+    function(cores)
+{
+    "cluster" %in% class(cores) && "SOCKcluster" %in% class(cores)
+}
+
+# number of cores being used
+n_cores <-
+    function(cores)
+{
+    if(is_cluster(cores)) return( length(cores) )
+    cores
+}
+
+# set up a cluster
+setup_cluster <-
+    function(cores, quiet=TRUE)
+{
+    if(is_cluster(cores)) return(cores)
+
+    if(cores==0) cores <- parallel::detectCores() # if 0, detect cores
+
+    if(cores > 1 && Sys.info()[1] == "Windows") { # windows doesn't support mclapply
+        cores <- parallel::makeCluster(cores)
+        do.call("on.exit",
+                list(quote(parallel::stopCluster(cores))),
+                envir=parent.frame())
+    }
+    cores
+}
+
+# run code by cluster
+# (to deal with different methods on different architectures)
+run_by_cluster <-
+    function(cores, ...)
+{
+    if(is_cluster(cores)) { # cluster object; use mclapply
+        return( parallel::clusterApply(cores, ...) )
+    } else {
+        if(cores==1) return( lapply(...) )
+        return( parallel::mclapply(..., mc.cores=cores) )
+    }
+}

--- a/R/cluster_util.R
+++ b/R/cluster_util.R
@@ -1,7 +1,7 @@
 # code related to clusters
-# (copy of code also in qtl2geno)
+# (repeating this code in both qtl2geno and qtl2scan)
 
-# test if input is a prepared cluster
+# test if input is a prepared cluster (vs. just a number)
 is_cluster <-
     function(cores)
 {
@@ -26,6 +26,8 @@ setup_cluster <-
 
     if(cores > 1 && Sys.info()[1] == "Windows") { # windows doesn't support mclapply
         cores <- parallel::makeCluster(cores)
+        # the following calls on.exit() in the function that called this one
+        # see http://stackoverflow.com/a/20998531
         do.call("on.exit",
                 list(quote(parallel::stopCluster(cores))),
                 envir=parent.frame())
@@ -35,6 +37,7 @@ setup_cluster <-
 
 # run code by cluster
 # (to deal with different methods on different architectures)
+# if cores==1, just use lapply
 run_by_cluster <-
     function(cores, ...)
 {


### PR DESCRIPTION
- Pull out repeated code to separate functions.
- Including the same `R/cluster_util.R` file in both [qtl2scan](https://github.com/kbroman/qtl2scan) and [qtl2geno](https://github.com/kbroman/qtl2geno).
