### PR TITLE
Aligning individuals and dealing with NAs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.3-13
-Date: 2015-12-08
+Version: 0.3-14
+Date: 2015-12-09
 Title: Genome Scans for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/covariates.R
+++ b/R/covariates.R
@@ -17,12 +17,11 @@ force_intcovar <-
     if(!is.matrix(addcovar)) addcovar <- as.matrix(addcovar)
     if(!is.matrix(intcovar)) intcovar <- as.matrix(intcovar)
 
-    stopifnot(nrow(addcovar) == nrow(intcovar))
-    n.addcovar <- ncol(addcovar)
-    n.intcovar <- ncol(intcovar)
+    # IDs in both
+    ids <- get_common_ids(addcovar, intcovar)
 
-    # look for matching columns
-    full <- cbind(addcovar, intcovar)
+    # look for matching columns, having reduced to common individuals
+    full <- cbind(addcovar[ids,,drop=FALSE], intcovar[ids,,drop=FALSE])
     has_match <- find_matching_cols(full, tol)
     if(any(has_match > 0))
         full <- full[, has_match<0, drop=FALSE]
@@ -66,10 +65,11 @@ drop_xcovar <-
     if(!is.matrix(covar)) covar <- as.matrix(covar)
     if(!is.matrix(Xcovar)) Xcovar <- as.matrix(Xcovar)
 
-    stopifnot(nrow(covar) == nrow(Xcovar))
+    # IDs in both
+    ids <- get_common_ids(covar, Xcovar)
 
-    # find columns that match a previous column
-    matches <- find_matching_cols(cbind(covar, Xcovar), tol)[-(1:ncol(covar))]
+    # look for matching columns, having reduced to common individuals
+    matches <- find_matching_cols(cbind(covar[ids,], Xcovar[ids,]), tol)[-(1:ncol(covar))]
 
     if(all(matches > 0)) return(NULL)
 

--- a/R/covariates.R
+++ b/R/covariates.R
@@ -17,8 +17,9 @@ force_intcovar <-
     if(!is.matrix(addcovar)) addcovar <- as.matrix(addcovar)
     if(!is.matrix(intcovar)) intcovar <- as.matrix(intcovar)
 
-    # IDs in both
-    ids <- get_common_ids(addcovar, intcovar)
+    # IDs in both; omitting any individuals with missing values
+    ids <- get_common_ids(addcovar[complete.cases(addcovar),,drop=FALSE],
+                          intcovar[complete.cases(intcovar),,drop=FALSE])
 
     # look for matching columns, having reduced to common individuals
     full <- cbind(addcovar[ids,,drop=FALSE], intcovar[ids,,drop=FALSE])
@@ -65,8 +66,9 @@ drop_xcovar <-
     if(!is.matrix(covar)) covar <- as.matrix(covar)
     if(!is.matrix(Xcovar)) Xcovar <- as.matrix(Xcovar)
 
-    # IDs in both
-    ids <- get_common_ids(covar, Xcovar)
+    # IDs in both; omitting any individuals with missing values
+    ids <- get_common_ids(covar[complete.cases(covar),,drop=FALSE],
+                          Xcovar[complete.cases(Xcovar),,drop=FALSE])
 
     # look for matching columns, having reduced to common individuals
     matches <- find_matching_cols(cbind(covar[ids,], Xcovar[ids,]), tol)[-(1:ncol(covar))]

--- a/R/covariates.R
+++ b/R/covariates.R
@@ -39,15 +39,14 @@ drop_depcols <-
 {
     if(is.null(covar)) return(covar)
 
-    if(any(is.na(covar)))
-        stop("covar shouldn't contain missing values")
-
     if(!is.matrix(covar)) covar <- as.matrix(covar)
     if(intercept) covar <- cbind(rep(1, nrow(covar)), covar)
 
     if(ncol(covar) <= 1) return(covar)
 
-    depcols <- sort(find_lin_indep_cols(covar, tol))
+    # deal with NAs by omitting those rows before
+    depcols <- sort(find_lin_indep_cols(covar[complete.cases(covar),,drop=FALSE], tol))
+
     if(intercept) {
         if(depcols[1] != 1)
             message("oops in drop_depcols; I figured the intercept would always be included.")

--- a/tests/testthat/test-drop_depcols.R
+++ b/tests/testthat/test-drop_depcols.R
@@ -80,6 +80,14 @@ test_that("drop_xcovar works with NAs", {
     expect_equal( drop_xcovar(cbind(int, Xcovar), Xcovar), NULL)
     expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar), NULL)
 
+    # try some permutations
+    o <- sample(1:n)
+    expect_equal( drop_xcovar(int, Xcovar[o]), as.matrix(Xcovar[o]))
+    expect_equal( drop_xcovar(Xcovar, Xcovar[o]), NULL)
+    expect_equal( drop_xcovar(cbind(int, Xcovar), Xcovar[o]), NULL)
+    expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar[o]), NULL)
+
+    # multiple X covar columns
     pgm <- sample(0:1, n, replace=TRUE)
     names(pgm) <- paste(1:n)
     Xcovar <- cbind(Xcovar, pgm)
@@ -96,9 +104,14 @@ test_that("drop_xcovar works with NAs", {
 
     # try some permutations
     o <- sample(1:n)
-    expect_equal( drop_xcovar(int, Xcovar[o]), as.matrix(Xcovar[o]))
-    expect_equal( drop_xcovar(Xcovar, Xcovar[o]), NULL)
-    expect_equal( drop_xcovar(cbind(int, Xcovar), Xcovar[o]), NULL)
-    expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar[o]), NULL)
+    expect_equal( drop_xcovar(int, Xcovar[o,]), Xcovar[o,])
+    expect_equal( drop_xcovar(Xcovar, Xcovar[o,]), NULL)
+    expect_equal( drop_xcovar(cbind(int, Xcovar), Xcovar[o,]), NULL)
+    expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar[o,]), NULL)
+    expect_equal( drop_xcovar(cbind(int, Xcovar[,1]), Xcovar[o,]), Xcovar[o,2,drop=FALSE])
+    expect_equal( drop_xcovar(cbind(int, Xcovar[,2]), Xcovar[o,]), Xcovar[o,1,drop=FALSE])
+    expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar[o,]), NULL)
+    expect_equal( drop_xcovar(cbind(Xcovar[,1], int), Xcovar[o,]), Xcovar[o,2,drop=FALSE])
+    expect_equal( drop_xcovar(cbind(Xcovar[,2], int), Xcovar[o,]), Xcovar[o,1,drop=FALSE])
 
 })

--- a/tests/testthat/test-drop_depcols.R
+++ b/tests/testthat/test-drop_depcols.R
@@ -64,3 +64,41 @@ test_that("drop_xcovar works", {
     expect_equal( drop_xcovar(cbind(Xcovar[,2], int), Xcovar), Xcovar[,1,drop=FALSE])
 
 })
+
+test_that("drop_xcovar works with NAs", {
+
+    set.seed(20151202)
+    n <- 100
+    Xcovar <- sample(0:1, n, replace=TRUE)
+    int <- rep(1, n)
+    names(Xcovar) <- names(int) <- paste(1:n)
+    Xcovar[3:5] <- NA
+
+    expect_equal( drop_xcovar(NULL, Xcovar), Xcovar)
+    expect_equal( drop_xcovar(int, Xcovar), as.matrix(Xcovar))
+    expect_equal( drop_xcovar(Xcovar, Xcovar), NULL)
+    expect_equal( drop_xcovar(cbind(int, Xcovar), Xcovar), NULL)
+    expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar), NULL)
+
+    pgm <- sample(0:1, n, replace=TRUE)
+    names(pgm) <- paste(1:n)
+    Xcovar <- cbind(Xcovar, pgm)
+
+    expect_equal( drop_xcovar(NULL, Xcovar), Xcovar)
+    expect_equal( drop_xcovar(int, Xcovar), Xcovar)
+    expect_equal( drop_xcovar(Xcovar, Xcovar), NULL)
+    expect_equal( drop_xcovar(cbind(int, Xcovar), Xcovar), NULL)
+    expect_equal( drop_xcovar(cbind(int, Xcovar[,1]), Xcovar), Xcovar[,2,drop=FALSE])
+    expect_equal( drop_xcovar(cbind(int, Xcovar[,2]), Xcovar), Xcovar[,1,drop=FALSE])
+    expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar), NULL)
+    expect_equal( drop_xcovar(cbind(Xcovar[,1], int), Xcovar), Xcovar[,2,drop=FALSE])
+    expect_equal( drop_xcovar(cbind(Xcovar[,2], int), Xcovar), Xcovar[,1,drop=FALSE])
+
+    # try some permutations
+    o <- sample(1:n)
+    expect_equal( drop_xcovar(int, Xcovar[o]), as.matrix(Xcovar[o]))
+    expect_equal( drop_xcovar(Xcovar, Xcovar[o]), NULL)
+    expect_equal( drop_xcovar(cbind(int, Xcovar), Xcovar[o]), NULL)
+    expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar[o]), NULL)
+
+})

--- a/tests/testthat/test-drop_depcols.R
+++ b/tests/testthat/test-drop_depcols.R
@@ -39,6 +39,7 @@ test_that("drop_xcovar works", {
     n <- 100
     Xcovar <- sample(0:1, n, replace=TRUE)
     int <- rep(1, n)
+    names(Xcovar) <- names(int) <- paste(1:n)
 
     expect_equal( drop_xcovar(NULL, NULL), NULL)
     expect_equal( drop_xcovar(NULL, Xcovar), Xcovar)
@@ -49,6 +50,7 @@ test_that("drop_xcovar works", {
     expect_equal( drop_xcovar(cbind(Xcovar, int), Xcovar), NULL)
 
     pgm <- sample(0:1, n, replace=TRUE)
+    names(pgm) <- paste(1:n)
     Xcovar <- cbind(Xcovar, pgm)
 
     expect_equal( drop_xcovar(NULL, Xcovar), Xcovar)

--- a/tests/testthat/test-force_intcovar.R
+++ b/tests/testthat/test-force_intcovar.R
@@ -47,3 +47,45 @@ test_that("force_intcovar works", {
     expect_equal(force_intcovar(X[,-3], X[,3]), X)
 
 })
+
+
+test_that("force_intcovar works with missing data", {
+
+    set.seed(20151130)
+    n.ind <- 100
+    X <- cbind(1,
+               sample(0:1, n.ind, replace=TRUE),
+               sample(0:1, n.ind, replace=TRUE))
+    rownames(X) <- paste(1:n.ind)
+
+    # add a few missing values
+    X[1,1] <- X[2:3,2] <- X[3:5,3] <- NA
+
+    expect_equal(force_intcovar(X, NULL), X)
+    expect_equal(force_intcovar(NULL, X), X)
+
+    expect_equal(force_intcovar(X, X), X[-(1:5),])
+
+    for(i in 1:ncol(X))
+        expect_equal(force_intcovar(X, X[,i]), X[-(1:5),])
+
+    expect_equal(force_intcovar(X[,1], X), X[-(1:5),])
+    expect_equal(force_intcovar(X[,2], X), X[-(1:5),c(2,1,3)])
+    expect_equal(force_intcovar(X[,3], X), X[-(1:5),c(3,1,2)])
+
+    expect_equal(force_intcovar(X[,-1], X[,1]), X[-(1:5),c(2,3,1)])
+    expect_equal(force_intcovar(X[,-2], X[,2]), X[-(1:5),c(1,3,2)])
+    expect_equal(force_intcovar(X[,-3], X[,3]), X[-(1:5),])
+
+    expect_equal(force_intcovar(X[,1], X[,2]), X[-(1:3),-3])
+    expect_equal(force_intcovar(X[,1], X[,3]), X[-c(1,3:5),-2])
+    expect_equal(force_intcovar(X[,2], X[,1]), X[-(1:3),c(2,1)])
+    expect_equal(force_intcovar(X[,2], X[,3]), X[-(2:5), -1])
+    expect_equal(force_intcovar(X[,3], X[,1]), X[-c(1,3:5),c(3,1)])
+    expect_equal(force_intcovar(X[,3], X[,2]), X[-(2:5),c(3,2)])
+
+    # try some permutations
+    expect_equal(force_intcovar(X, X[sample(1:nrow(X)),]), X[-(1:5),])
+    expect_equal(force_intcovar(X[,-1], X[sample(1:nrow(X)),1]), X[-(1:5),c(2,3,1)])
+
+})

--- a/tests/testthat/test-force_intcovar.R
+++ b/tests/testthat/test-force_intcovar.R
@@ -1,6 +1,6 @@
 context("force intcovar into addcovar")
 
-test_that("find_matchin_cols works", {
+test_that("find_matching_cols works", {
 
     set.seed(20151130)
     x <- cbind(1, sample(0:1, 200, repl=TRUE))
@@ -26,6 +26,7 @@ test_that("force_intcovar works", {
     X <- cbind(1,
                sample(0:1, n.ind, replace=TRUE),
                sample(0:1, n.ind, replace=TRUE))
+    rownames(X) <- paste(1:n.ind)
 
     expect_equal(force_intcovar(NULL, NULL), NULL)
 

--- a/tests/testthat/test-scan1.R
+++ b/tests/testthat/test-scan1.R
@@ -21,6 +21,9 @@ lod_via_lm <-
 
     for(i in 1:p) {
         not_na <- !is.na(pheno[,i])
+        if(!is.null(addcovar)) not_na <- not_na & complete.cases(addcovar)
+        if(!is.null(intcovar)) not_na <- not_na & complete.cases(intcovar)
+
         rss0 <- sum(lm(pheno[,i] ~ -1 + addcovar, weights=wts)$resid^2*wts[not_na])
         for(j in 1:d3) {
             if(is.null(intcovar))
@@ -286,4 +289,48 @@ test_that("scan1 for backcross with multiple phenotypes with NAs", {
     out.lm <- lod_via_lm(pr[[18]], y, x, intcovar=x, weights=w)
     expect_equal(subset_scan1result(out2, lm_rows), out.lm)
 
+})
+
+
+test_that("scan1 works with NAs in the covariates", {
+
+    set.seed(20151202)
+    library(qtl)
+    data(hyper)
+
+    # phenotypes
+    n_phe <- 15
+    n_ind <- nind(hyper)
+    y <- matrix(rnorm(n_ind*n_phe), ncol=n_phe)
+    # 5 batches
+    spl <- split(sample(1:n_phe), rep(1:5, 3))
+    nmis <- c(0, 5, 10, 15, 20)
+    for(i in seq(along=spl)[-1])
+        y[sample(1:n_ind, nmis[i]), spl[[i]]] <- NA
+
+    # scan by R/qtl
+    hyper$pheno <- cbind(y, hyper$pheno[,2,drop=FALSE])
+    hyper <- calc.genoprob(hyper, step=2.5)
+
+    # inputs for R/qtl2
+    pr <- lapply(hyper$geno, function(a) aperm(a$prob, c(1,3,2)))
+    rownames(y) <- paste(1:n_ind)
+    for(i in seq(along=pr)) rownames(pr[[i]]) <- rownames(y)
+    posnames <- unlist(lapply(pr, function(a) dimnames(a)[[3]]))
+
+    ##############################
+    # additive covariate
+    x <- sample(0:1, n_ind, replace=TRUE)
+    names(x) <- rownames(y)
+    x[5] <- NA
+
+    suppressWarnings(out <- scanone(hyper, method="hk", addcovar=x, pheno.col=1:n_phe))
+    out2 <- scan1(pr, y, x)
+    expect_equal(out2, scanone2scan1(out, colSums(!(is.na(y) | is.na(x))),
+                                     posnames, colnames(y), addcovar=x))
+
+    # cf lm() for chr 1
+    lm_rows <- which(out[,1]==18)
+    out.lm <- lod_via_lm(pr[[18]], y, x)
+    expect_equal(subset_scan1result(out2, lm_rows), out.lm)
 })

--- a/tests/testthat/test-scan1.R
+++ b/tests/testthat/test-scan1.R
@@ -186,10 +186,10 @@ test_that("scan1 for backcross with multiple phenotypes with NAs", {
     n_ind <- nind(hyper)
     y <- matrix(rnorm(n_ind*n_phe), ncol=n_phe)
     # 5 batches
-    spl <- split(sample(1:n_phe), rep(1:5, 3))
+    spl <- split(sample(n_phe), rep(1:5, 3))
     nmis <- c(0, 5, 10, 15, 20)
     for(i in seq(along=spl)[-1])
-        y[sample(1:n_ind, nmis[i]), spl[[i]]] <- NA
+        y[sample(n_ind, nmis[i]), spl[[i]]] <- NA
 
     # scan by R/qtl
     hyper$pheno <- cbind(y, hyper$pheno[,2,drop=FALSE])
@@ -303,10 +303,10 @@ test_that("scan1 works with NAs in the covariates", {
     n_ind <- nind(hyper)
     y <- matrix(rnorm(n_ind*n_phe), ncol=n_phe)
     # 5 batches
-    spl <- split(sample(1:n_phe), rep(1:5, 3))
+    spl <- split(sample(n_phe), rep(1:5, 3))
     nmis <- c(0, 5, 10, 15, 20)
     for(i in seq(along=spl)[-1])
-        y[sample(1:n_ind, nmis[i]), spl[[i]]] <- NA
+        y[sample(n_ind, nmis[i]), spl[[i]]] <- NA
 
     # scan by R/qtl
     hyper$pheno <- cbind(y, hyper$pheno[,2,drop=FALSE])
@@ -333,4 +333,90 @@ test_that("scan1 works with NAs in the covariates", {
     lm_rows <- which(out[,1]==18)
     out.lm <- lod_via_lm(pr[[18]], y, x)
     expect_equal(subset_scan1result(out2, lm_rows), out.lm)
+})
+
+
+test_that("scan1 aligns the individuals", {
+
+    set.seed(20151202)
+    library(qtl)
+    data(hyper)
+
+    # phenotypes
+    n_phe <- 15
+    n_ind <- nind(hyper)
+    y <- matrix(rnorm(n_ind*n_phe), ncol=n_phe)
+    # 5 batches
+    spl <- split(sample(n_phe), rep(1:5, 3))
+    nmis <- c(0, 5, 10, 15, 20)
+    for(i in seq(along=spl)[-1])
+        y[sample(n_ind, nmis[i]), spl[[i]]] <- NA
+
+    # scan by R/qtl
+    hyper$pheno <- cbind(y, hyper$pheno[,2,drop=FALSE])
+    hyper <- calc.genoprob(hyper, step=2.5)
+
+    # inputs for R/qtl2
+    pr <- lapply(hyper$geno, function(a) aperm(a$prob, c(1,3,2)))
+    rownames(y) <- paste(1:n_ind)
+    for(i in seq(along=pr)) rownames(pr[[i]]) <- rownames(y)
+    posnames <- unlist(lapply(pr, function(a) dimnames(a)[[3]]))
+
+    # scan
+    out <- scan1(pr, y)
+    out_perm <- scan1(pr, y[sample(n_ind),])
+    expect_equal(out_perm, out)
+
+    class(pr) <- c("calc_genoprob", "list") # allows simpler reordering of individuals
+    out_perm <- scan1(pr[sample(n_ind),], y)
+    expect_equal(out_perm, out)
+
+    ##############################
+    # weighted scan
+    w <- runif(n_ind, 1, 3)
+    names(w) <- rownames(y)
+
+    out <- scan1(pr, y, weights=w)
+    out_perm <- scan1(pr[sample(n_ind),], y[sample(n_ind),], weights=w[sample(n_ind)])
+    expect_equal(out_perm, out)
+
+    ##############################
+    # additive covariate
+    x <- sample(0:1, n_ind, replace=TRUE)
+    names(x) <- rownames(y)
+
+    out <- scan1(pr, y, x)
+    out_perm <- scan1(pr[sample(n_ind),], y[sample(n_ind),], x[sample(n_ind)])
+    expect_equal(out_perm, out)
+
+    ##############################
+    # additive covariate + weights
+    out <- scan1(pr, y, x, weights=w)
+    out_perm <- scan1(pr[sample(n_ind),], y[sample(n_ind),], x[sample(n_ind)],
+                      weights=w[sample(n_ind)])
+    expect_equal(out_perm, out)
+
+    ##############################
+    # interactive covariate
+    out <- scan1(pr, y, x, intcovar=x)
+    out_perm <- scan1(pr[sample(n_ind),], y[sample(n_ind),], x[sample(n_ind)],
+                      intcovar=x[sample(n_ind)])
+    expect_equal(out_perm, out)
+
+    # auto add intcovar?
+    out_perm <- scan1(pr[sample(n_ind),], y[sample(n_ind),], intcovar=x[sample(n_ind)])
+    expect_equal(out_perm, out)
+
+    ##############################
+    # interactive covariate + weights
+    out <- scan1(pr, y, x, intcovar=x, weights=w)
+    out_perm <- scan1(pr[sample(n_ind),], y[sample(n_ind),], x[sample(n_ind)],
+                      intcovar=x[sample(n_ind)], weights=w[sample(n_ind)])
+    expect_equal(out_perm, out)
+
+    # auto add intcovar?
+    out_perm <- scan1(pr[sample(n_ind),], y[sample(n_ind),],
+                      intcovar=x[sample(n_ind)], weights=w[sample(n_ind)])
+    expect_equal(out_perm, out)
+
 })


### PR DESCRIPTION
- Revised `force_intcovar()` and `drop_xcovar()` to align individuals properly and deal with `NA`s
- Revised `drop_depcols()` to deal with `NA`s.
- Added tests of all of these, plus of `scan1()` aligning individuals.

Fixes Issues #27 and #28.
