### PR TITLE
Simplify convert2scan1(); map now included in scan1() output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.3-23
-Date: 2016-02-19
+Version: 0.3-24
+Date: 2016-02-22
 Title: Genome Scans for QTL Experiments
 Description: Functions to calculate QTL genotype probabilities, impute
     QTL genotypes, and estimate genetic maps. Part of R/qtl2, a

--- a/R/convert2scanone.R
+++ b/R/convert2scanone.R
@@ -8,12 +8,6 @@
 #'
 #' @param output Matrix of LOD scores, as calculated by
 #' \code{\link{scan1}} or \code{\link{scan1_lmm}}.
-#' @param probs Genotype probabilities (calculated with the qtl2geno
-#' function \code{calc_genoprob}) used to calculate \code{output}. It
-#' includes, as an attribute, the map of positions at which the LOD
-#' scores were calculated.
-#' @param map Genetic map of positions at which the LOD scores were
-#' calculated. (Needed if \code{probs} is not provided.)
 #'
 #' @return A data frame with class \code{"scanone"}, containing
 #' chromosome and position columns followed by the LOD scores in
@@ -32,13 +26,13 @@
 #' Xcovar <- get_x_covar(iron)
 #' out <- scan1(probs, pheno, covar, Xcovar)
 #'
-#' out_rev <- convert2scanone(out, probs)
+#' out_rev <- convert2scanone(out)
 #'
 #' @export
 convert2scanone <-
-    function(output, probs, map)
+    function(output)
 {
-    if(missing(map)) map <- attr(probs, "map")
+    map <- attr(output, "map")
     n <- sapply(map, length)
 
     stopifnot(sum(n) == nrow(output))

--- a/man/convert2scanone.Rd
+++ b/man/convert2scanone.Rd
@@ -4,19 +4,11 @@
 \alias{convert2scanone}
 \title{Convert scan1 results to the scanone format}
 \usage{
-convert2scanone(output, probs, map)
+convert2scanone(output)
 }
 \arguments{
 \item{output}{Matrix of LOD scores, as calculated by
 \code{\link{scan1}} or \code{\link{scan1_lmm}}.}
-
-\item{probs}{Genotype probabilities (calculated with the qtl2geno
-function \code{calc_genoprob}) used to calculate \code{output}. It
-includes, as an attribute, the map of positions at which the LOD
-scores were calculated.}
-
-\item{map}{Genetic map of positions at which the LOD scores were
-calculated. (Needed if \code{probs} is not provided.)}
 }
 \value{
 A data frame with class \code{"scanone"}, containing
@@ -42,7 +34,7 @@ names(covar) <- rownames(iron$covar)
 Xcovar <- get_x_covar(iron)
 out <- scan1(probs, pheno, covar, Xcovar)
 
-out_rev <- convert2scanone(out, probs)
+out_rev <- convert2scanone(out)
 
 }
 

--- a/man/scan1.Rd
+++ b/man/scan1.Rd
@@ -36,7 +36,10 @@ produced by \code{\link[parallel]{makeCluster}}.}
 A matrix of LOD scores, positions x phenotypes.  Covariate
 column names are included as attributes (\code{"addcovar"},
 \code{"intcovar"}, and \code{"Xcovar"}), as is a vector with the
-sample size for each phenotype (\code{"sample_size"})
+sample size for each phenotype (\code{"sample_size"}). The map of
+positions at which the calculations were performed is included as
+an attribute \code{"map"} (taken from the corresponding attribute
+in the input \code{genoprobs}).
 }
 \description{
 Genome scan with a single-QTL model by Haley-Knott regression, with possible allowance for covariates.

--- a/man/scan1_lmm.Rd
+++ b/man/scan1_lmm.Rd
@@ -40,7 +40,10 @@ Heritabilities (estimated under the null hypothesis, of no QTL) are
 included as an attribute \code{hsq}. Covariate column names are
 included as attributes (\code{"addcovar"}, \code{"intcovar"}, and
 \code{"Xcovar"}), as is a vector with the sample size for each
-phenotype (\code{"sample_size"})
+phenotype (\code{"sample_size"}). The map of positions at which the
+calculations were performed is included as an attribute
+\code{"map"} (taken from the corresponding attribute in the input
+\code{genoprobs}).
 }
 \description{
 Genome scan with a single-QTL and linear mixed model to account for

--- a/man/scan1coef.Rd
+++ b/man/scan1coef.Rd
@@ -36,7 +36,10 @@ columns are linearly dependent on others and should be omitted)}
 \value{
 A matrix of estimated regression coefficients, of dimension
 positions x number of effects. The number of effects is
-\code{n_genotypes + n_addcovar + (n_genotypes-1)*n_intcovar}
+\code{n_genotypes + n_addcovar + (n_genotypes-1)*n_intcovar}. The
+map of positions at which the calculations were performed is
+included as an attribute \code{"map"} (taken from the corresponding
+attribute in the input \code{genoprobs}).
 }
 \description{
 Calculate QTL effects in scan along one chromosome with a
@@ -54,16 +57,16 @@ library(qtl2geno)
 # read data
 iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
 
-# calculate genotype probabilities just for chromosome 7
-probs <- calc_genoprob(iron[,7], step=1, error_prob=0.002)
+# calculate genotype probabilities
+probs <- calc_genoprob(iron, step=1, error_prob=0.002)
 
 # grab phenotypes and covariates; ensure that covariates have names attribute
 pheno <- iron$pheno[,1]
 covar <- match(iron$covar$sex, c("f", "m")) # make numeric
 names(covar) <- rownames(iron$covar)
 
-# perform genome scan
-coef <- scan1coef(probs[[1]], pheno, covar)
+# calculate coefficients for chromosome 7
+coef <- scan1coef(probs[,7], pheno, covar)
 
 }
 \references{

--- a/vignettes/user_guide.Rmd
+++ b/vignettes/user_guide.Rmd
@@ -305,7 +305,7 @@ summarizing the results of `scan1()`, but you can use the function
 R/qtl functions for displaying the results.
 
 ```{r convert2scanone}
-out_scanone <- convert2scanone(out, pr)
+out_scanone <- convert2scanone(out)
 ```
 
 We can now plot the LOD curves as follows:
@@ -351,8 +351,8 @@ the R/qtl `scanone` format.
 
 
 ```{r convert2scanone_lmm}
-out_lmm_scanone <- convert2scanone(out_lmm, pr)
-out_lmm_loco_scanone <- convert2scanone(out_lmm_loco, pr)
+out_lmm_scanone <- convert2scanone(out_lmm)
+out_lmm_loco_scanone <- convert2scanone(out_lmm_loco)
 ```
 
 Here is a plot of the LOD scores, by Haley-Knott regression and the linear


### PR DESCRIPTION
No longer need to include genoprobs or map as argument, because the map is now included as an attribute in the output of `scan1()` and `scan1lmm()`.
