### PR TITLE
Check for square matrix in decomp_kinship() + add NULL default args

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.4-7
-Date: 2016-03-09
+Version: 0.4-8
+Date: 2016-03-11
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a
     reimplementation of the R/qtl package to better handle

--- a/R/arg_util.R
+++ b/R/arg_util.R
@@ -5,11 +5,11 @@
 # default = default value for argument
 # values  = optional vector of character strings with possible values
 grab_dots <-
-    function(dotargs, argname, default, values)
+    function(dotargs, argname, default, values=NULL)
 {
     if(argname %in% names(dotargs)) {
         arg <- dotargs[[argname]]
-        if(!missing(values) && !is.null(values) && !(arg %in% values)) {
+        if(!is.null(values) && !(arg %in% values)) {
             warning(argname, ' "', arg, '" not valid; using "',
                     default, '".')
             arg <- default

--- a/R/decomp_kinship.R
+++ b/R/decomp_kinship.R
@@ -29,7 +29,11 @@ decomp_kinship <-
     # already done?
     if(!is.null(attr(kinship, "eigen_decomp"))) return(kinship)
 
-    if(is.matrix(kinship)) return(Rcpp_eigen_decomp(kinship))
+    if(is.matrix(kinship)) {
+        if(ncol(kinship) != nrow(kinship))
+            stop("matrix must be square")
+        return(Rcpp_eigen_decomp(kinship))
+    }
 
     cores <- setup_cluster(cores)
 

--- a/R/pick_marker_subset.R
+++ b/R/pick_marker_subset.R
@@ -45,10 +45,8 @@
 #' # subset to markers that are >= 1 cM apart
 #' gmap_sub <- pick_marker_subset(gmap, 1)
 pick_marker_subset <-
-    function(map, min_d=1, weights)
+    function(map, min_d=1, weights=NULL)
 {
-    if(missing(weights)) weights <- NULL
-
     # multiple chromosomes
     if(is.list(map)) {
         if(!is.null(weights)) {

--- a/R/scan1coef_lmm.R
+++ b/R/scan1coef_lmm.R
@@ -73,7 +73,7 @@ scan1coef_lmm <-
     function(genoprobs, pheno, kinship,
              addcovar=NULL, intcovar=NULL,
              contrasts=NULL, se=FALSE,
-             hsq, reml=TRUE, tol=1e-12)
+             hsq=NULL, reml=TRUE, tol=1e-12)
 {
     stopifnot(tol > 0)
 
@@ -155,7 +155,7 @@ scan1coef_lmm <-
         kinship <- decomp_kinship(kinship[ind2keep, ind2keep])
 
     # estimate hsq if necessary
-    if(missing(hsq) || is.null(hsq)) {
+    if(is.null(hsq)) {
         nullresult <- calc_hsq_clean(kinship, as.matrix(pheno), addcovar, NULL, FALSE,
                                      reml, cores=1, check_boundary=TRUE, tol)
         hsq <- nullresult$hsq

--- a/R/subset_scan1.R
+++ b/R/subset_scan1.R
@@ -41,12 +41,12 @@
 #' out_c2_spleen <- subset(out, "2", "spleen")
 #' }
 subset_scan1 <-
-    function(x, chr, lodcolumn, ...)
+    function(x, chr=NULL, lodcolumn=NULL, ...)
 {
     map <- x$map
 
     # subset by chromosome
-    if(!missing(chr) && !is.null(chr)) {
+    if(!is.null(chr)) {
         # selected chromosomes
         chr_found <- chr %in% names(map)
         if(!all(chr_found))
@@ -75,7 +75,7 @@ subset_scan1 <-
         }
     }
 
-    if(!missing(lodcolumn) && !is.null(lodcolumn)) {
+    if(!is.null(lodcolumn)) {
         if(is.character(lodcolumn)) {
             if(!is.null(x$lod)) cols <- colnames(x$lod)
             else if(!is.null(x$coef)) cols <- colnames(x$coef)
@@ -107,7 +107,7 @@ subset.scan1 <- subset_scan1
 #' @export
 #' @rdname subset_scan1
 `[.scan1` <-
-    function(x, chr, lodcolumn)
+    function(x, chr=NULL, lodcolumn=NULL)
     subset(x, chr, lodcolumn)
 
 

--- a/R/summary_scan1.R
+++ b/R/summary_scan1.R
@@ -45,7 +45,7 @@
 #' # maximum of first column on chr 2
 #' max(out, chr="2")
 max_scan1 <-
-    function(scan1_output, lodcolumn=1, chr, na.rm=TRUE, ...)
+    function(scan1_output, lodcolumn=1, chr=NULL, na.rm=TRUE, ...)
 {
     thechr <- chr_scan1(scan1_output)
     thepos <- pos_scan1(scan1_output)
@@ -84,7 +84,7 @@ max_scan1 <-
     sign <- sign[,lodcolumn]
 
     # subset chromosomes
-    if(!missing(chr) && !is.null(chr)) {
+    if(!is.null(chr)) {
         keep <- (thechr %in% chr)
         thechr <- thechr[keep]
         thepos <- thepos[keep]
@@ -106,7 +106,9 @@ max_scan1 <-
 
 #' @export
 #' @rdname max_scan1
-max.scan1 <- max_scan1
+max.scan1 <-
+    function(scan1_output, lodcolumn=1, chr=NULL, na.rm=TRUE, ...)
+    max_scan1(scan1_output, lodcolumn, chr, na.rm, ...)
 
 #' Overall maximum LOD score
 #'
@@ -147,7 +149,7 @@ max.scan1 <- max_scan1
 #' max(out, "2")
 #' }
 maxlod <-
-    function(scan1_output, chr)
+    function(scan1_output, chr=NULL)
 {
     # subset by chromosome
     scan1_output <- subset(scan1_output, chr=chr)

--- a/man/max_scan1.Rd
+++ b/man/max_scan1.Rd
@@ -5,9 +5,10 @@
 \alias{max_scan1}
 \title{Find position with maximum LOD score}
 \usage{
-max_scan1(scan1_output, lodcolumn = 1, chr, na.rm = TRUE, ...)
+max_scan1(scan1_output, lodcolumn = 1, chr = NULL, na.rm = TRUE, ...)
 
-\method{max}{scan1}(scan1_output, lodcolumn = 1, chr, na.rm = TRUE, ...)
+\method{max}{scan1}(scan1_output, lodcolumn = 1, chr = NULL, na.rm = TRUE,
+  ...)
 }
 \arguments{
 \item{scan1_output}{An object of class \code{"scan1"} as returned by

--- a/man/maxlod.Rd
+++ b/man/maxlod.Rd
@@ -4,7 +4,7 @@
 \alias{maxlod}
 \title{Overall maximum LOD score}
 \usage{
-maxlod(scan1_output, chr)
+maxlod(scan1_output, chr = NULL)
 }
 \arguments{
 \item{scan1_output}{An object of class \code{"scan1"} as returned by

--- a/man/pick_marker_subset.Rd
+++ b/man/pick_marker_subset.Rd
@@ -4,7 +4,7 @@
 \alias{pick_marker_subset}
 \title{Identify the largest subset of markers that are some distance apart}
 \usage{
-pick_marker_subset(map, min_d = 1, weights)
+pick_marker_subset(map, min_d = 1, weights = NULL)
 }
 \arguments{
 \item{map}{Either a vector of marker positions, or a list of such

--- a/man/scan1coef_lmm.Rd
+++ b/man/scan1coef_lmm.Rd
@@ -5,7 +5,8 @@
 \title{Calculate QTL effects in scan along one chromosome, adjusting for polygenes with an LMM}
 \usage{
 scan1coef_lmm(genoprobs, pheno, kinship, addcovar = NULL, intcovar = NULL,
-  contrasts = NULL, se = FALSE, hsq, reml = TRUE, tol = 0.000000000001)
+  contrasts = NULL, se = FALSE, hsq = NULL, reml = TRUE,
+  tol = 0.000000000001)
 }
 \arguments{
 \item{genoprobs}{Genotype probabilities as calculated by

--- a/man/subset_scan1.Rd
+++ b/man/subset_scan1.Rd
@@ -6,11 +6,11 @@
 \alias{subset_scan1}
 \title{Subset scan1 output}
 \usage{
-subset_scan1(x, chr, lodcolumn, ...)
+subset_scan1(x, chr = NULL, lodcolumn = NULL, ...)
 
-\method{subset}{scan1}(x, chr, lodcolumn, ...)
+\method{subset}{scan1}(x, chr = NULL, lodcolumn = NULL, ...)
 
-\method{[}{scan1}(x, chr, lodcolumn)
+\method{[}{scan1}(x, chr = NULL, lodcolumn = NULL)
 }
 \arguments{
 \item{x}{An object of class \code{"scan1"} as returned by

--- a/src/lmm.cpp
+++ b/src/lmm.cpp
@@ -31,6 +31,9 @@ List Rcpp_eigen_decomp(const NumericMatrix& A)
     const MatrixXd AA(as<Map<MatrixXd> >(A));
     const std::pair<VectorXd,MatrixXd> result = eigen_decomp(AA);
 
+    if(A.cols() != A.rows())
+        throw std::invalid_argument("A must be a square matrix");
+
     // set dimnames of eigenvector matrix
     NumericMatrix eigenvec(wrap(result.second));
     eigenvec.attr("dimnames") = A.attr("dimnames");

--- a/tests/testthat/test-decomp_kinship.R
+++ b/tests/testthat/test-decomp_kinship.R
@@ -52,3 +52,14 @@ test_that("multi-core eigen decomposition works", {
     expect_equal(Ke_multicore, Ke)
 
 })
+
+
+test_that("eigen decomposition gives error with non-square matrix", {
+
+    k <- matrix(runif(100), ncol=5)
+    expect_error(decomp_eigen(k))
+
+    k <- list(k, matrix(runif(100), ncol=20))
+    expect_error(decomp_eigen(k))
+
+})


### PR DESCRIPTION
- I wasn't checking for the input matrix being square in `decomp_kinship()` and sending a non-square matrix could cause a core dump.
- Also, throughout the code any optional arguments now have `NULL` as the default, and so I've removed all calls to `missing()`.
