### PR TITLE
Fix estimates of heritability in scan1, etc.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.4-19
-Date: 2016-06-13
+Version: 0.4-20
+Date: 2016-06-16
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a
     reimplementation of the R/qtl package to better handle

--- a/R/est_herit.R
+++ b/R/est_herit.R
@@ -16,7 +16,13 @@
 #' @return A vector of estimated heritabilities, corresponding to the
 #' columns in \code{pheno}.
 #'
-#' @details For each of the inputs, the row names are used as
+#' @details
+#' We fit the model \eqn{y = X \beta + \epsilon}{y = Xb + e} where
+#' \eqn{\epsilon}{e} is multivariate normal with mean 0 and covariance
+#' matrix \eqn{\sigma^2 [h^2 (2 K) + I]}{sigmasq*[hsq*2*K+I]} where
+#' \eqn{K} is the kinship matrix and \eqn{I} is the identity matrix.
+#'
+#' For each of the inputs, the row names are used as
 #' individual identifiers, to align individuals.
 #'
 #' If \code{reml=TRUE}, restricted maximum likelihood (reml) is used
@@ -71,6 +77,10 @@ est_herit <-
 
     # check that kinship matrices are square with same IDs
     kinshipIDs <- nrow(kinship)
+
+    # multiply kinship matrix by 2; rest is using 2*kinship
+    # see Almasy & Blangero (1998) http://doi.org/10.1086/301844
+    kinship <- double_kinship(kinship)
 
     # find individuals in common across all arguments
     # and drop individuals with missing covariates or missing *all* phenotypes

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -55,7 +55,22 @@
 #'     which chromosomes are the X chromosome.
 #' }
 #'
-#' @details For each of the inputs, the row names are used as
+#' @details
+#' We first fit the model \eqn{y = X \beta + \epsilon}{y = Xb + e}
+#' where \eqn{X} is a matrix of covariates (or just an intercept) and
+#' \eqn{\epsilon}{e} is multivariate normal with mean 0 and covariance
+#' matrix \eqn{\sigma^2 [h^2 (2 K) + I]}{sigmasq*[hsq*2*K+I]} where
+#' \eqn{K} is the kinship matrix and \eqn{I} is the identity matrix.
+#'
+#' We then take \eqn{h^2}{hsq} as fixed and then scan the genome, at
+#' each genomic position fitting the model \eqn{y = P \alpha + X \beta
+#' + \epsilon}{y = Xb + e} where \eqn{P} is a matrix of genotype
+#' probabilities for the current position and again \eqn{X} is a
+#' matrix of covariates \eqn{\epsilon}{e} is multivariate normal with
+#' mean 0 and covariance matrix \eqn{\sigma^2 [h^2 (2 K) +
+#' I]}{sigmasq*[hsq*2*K+I]}, taking \eqn{h^2}{hsq} to be known.
+#'
+#' For each of the inputs, the row names are used as
 #' individual identifiers, to align individuals. The \code{genoprobs}
 #' object should have a component \code{"is_x_chr"} that indicates
 #' which of the chromosomes is the X chromosome, if any.

--- a/R/scan1blup_pg.R
+++ b/R/scan1blup_pg.R
@@ -49,6 +49,10 @@ scan1blup_pg <-
         did_decomp <- FALSE
     }
 
+    # multiply kinship matrix by 2; rest is using 2*kinship
+    # see Almasy & Blangero (1998) http://doi.org/10.1086/301844
+    kinship <- double_kinship(kinship)
+
     # find individuals in common across all arguments
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, pheno, kinshipIDs, addcovar, complete.cases=TRUE)

--- a/R/scan1coef_pg.R
+++ b/R/scan1coef_pg.R
@@ -53,6 +53,10 @@ scan1coef_pg <-
         did_decomp <- FALSE
     }
 
+    # multiply kinship matrix by 2; rest is using 2*kinship
+    # see Almasy & Blangero (1998) http://doi.org/10.1086/301844
+    kinship <- double_kinship(kinship)
+
     # find individuals in common across all arguments
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, pheno, kinshipIDs,

--- a/man/est_herit.Rd
+++ b/man/est_herit.Rd
@@ -31,6 +31,11 @@ Estimate the heritability of a set of traits via a linear mixed
 model, with possible allowance for covariates.
 }
 \details{
+We fit the model \eqn{y = X \beta + \epsilon}{y = Xb + e} where
+\eqn{\epsilon}{e} is multivariate normal with mean 0 and covariance
+matrix \eqn{\sigma^2 [h^2 (2 K) + I]}{sigmasq*[hsq*2*K+I]} where
+\eqn{K} is the kinship matrix and \eqn{I} is the identity matrix.
+
 For each of the inputs, the row names are used as
 individual identifiers, to align individuals.
 

--- a/man/scan1.Rd
+++ b/man/scan1.Rd
@@ -75,6 +75,20 @@ Genome scan with a single-QTL model by Haley-Knott regression or a
 linear mixed model, with possible allowance for covariates.
 }
 \details{
+We first fit the model \eqn{y = X \beta + \epsilon}{y = Xb + e}
+where \eqn{X} is a matrix of covariates (or just an intercept) and
+\eqn{\epsilon}{e} is multivariate normal with mean 0 and covariance
+matrix \eqn{\sigma^2 [h^2 (2 K) + I]}{sigmasq*[hsq*2*K+I]} where
+\eqn{K} is the kinship matrix and \eqn{I} is the identity matrix.
+
+We then take \eqn{h^2}{hsq} as fixed and then scan the genome, at
+each genomic position fitting the model \eqn{y = P \alpha + X \beta
++ \epsilon}{y = Xb + e} where \eqn{P} is a matrix of genotype
+probabilities for the current position and again \eqn{X} is a
+matrix of covariates \eqn{\epsilon}{e} is multivariate normal with
+mean 0 and covariance matrix \eqn{\sigma^2 [h^2 (2 K) +
+I]}{sigmasq*[hsq*2*K+I]}, taking \eqn{h^2}{hsq} to be known.
+
 For each of the inputs, the row names are used as
 individual identifiers, to align individuals. The \code{genoprobs}
 object should have a component \code{"is_x_chr"} that indicates

--- a/tests/testthat/test-scan1_pg.R
+++ b/tests/testthat/test-scan1_pg.R
@@ -17,6 +17,8 @@ test_that("scan1 with kinship with intercross, vs ported lmmlite code", {
     Ke <- decomp_kinship(kinship) # eigen decomp
     yp <- Ke$vectors %*% y
     Xp <- Ke$vectors %*% X
+    # double the eigenvalues (== kinship matrix * 2)
+    Ke$values <- Ke$values*2
 
     byhand1_reml <- Rcpp_fitLMM(Ke$values, yp[,1], Xp, reml=TRUE, tol=1e-12)
     byhand2_reml <- Rcpp_fitLMM(Ke$values, yp[,2], Xp, reml=TRUE, tol=1e-12)
@@ -72,6 +74,8 @@ test_that("scan1 with intercross with X covariates for null", {
     yp <- Ke$vectors %*% y
     Xp <- Ke$vectors %*% X
     Xcp <- Ke$vectors %*% Xc
+    # double the eigenvalues (== kinship matrix * 2)
+    Ke$values <- Ke$values*2
 
     byhand1_reml <- Rcpp_fitLMM(Ke$values, yp[,1], cbind(Xp, Xcp), reml=TRUE, tol=1e-12)
     byhand2_reml <- Rcpp_fitLMM(Ke$values, yp[,2], cbind(Xp, Xcp), reml=TRUE, tol=1e-12)
@@ -130,6 +134,8 @@ test_that("scan1 with kinship with intercross with an additive covariate", {
     yp <- Ke$vectors %*% y
     Xp <- Ke$vectors %*% cbind(1, X)
     Xcp <- Ke$vectors %*% Xc
+    # double the eigenvalues (== kinship matrix * 2)
+    Ke$values <- Ke$values*2
 
     # autosome null
     byhand1A_reml <- Rcpp_fitLMM(Ke$values, yp[,1], Xp, reml=TRUE, tol=1e-12)
@@ -237,6 +243,8 @@ test_that("scan1 with kinship with intercross with an interactive covariate", {
     yp <- Ke$vectors %*% y
     Xp <- Ke$vectors %*% cbind(1, X)
     Xcp <- Ke$vectors %*% Xc
+    # double the eigenvalues (== kinship matrix * 2)
+    Ke$values <- Ke$values*2
 
     # autosome null (same as w/o interactive covariate)
     byhand1A_reml <- Rcpp_fitLMM(Ke$values, yp[,1], Xp, reml=TRUE, tol=1e-12)
@@ -331,6 +339,8 @@ test_that("scan1 with kinship works with LOCO, additive covariates", {
 
     y <- iron$pheno
     Ke <- decomp_kinship(kinship) # eigen decomp
+    # double the eigenvalues (== kinship matrix * 2)
+    Ke <- lapply(Ke, function(a) { a$values <- 2*a$values; a})
 
     # compare chromosomes 1, 6, 9, 18
     chrs <- paste(c(1,6,9,18))
@@ -399,6 +409,8 @@ test_that("scan1 with kinship works with LOCO, interactive covariates", {
 
     y <- iron$pheno
     Ke <- decomp_kinship(kinship) # eigen decomp
+    # double the eigenvalues (== kinship matrix * 2)
+    Ke <- lapply(Ke, function(a) { a$values <- 2*a$values; a})
 
     # compare chromosomes 1, 6, 9, 18
     chrs <- paste(c(1,6,9,18))

--- a/tests/testthat/test-scan1coef_pg.R
+++ b/tests/testthat/test-scan1coef_pg.R
@@ -5,6 +5,7 @@ eff_via_lm <-
     function(probs, pheno, kinship, addcovar=NULL, intcovar=NULL,
              se=TRUE)
 {
+    kinship <- double_kinship(kinship) # need 2*kinship for LMM
     kinship <- decomp_kinship(kinship)
     eigenvec <- kinship$vectors
     hsq <- calc_hsq_clean(kinship, as.matrix(pheno), addcovar, NULL, FALSE,


### PR DESCRIPTION
- In `est_herit`, `scan1`, `scan1coef`, and `scan1blup`, correct the estimate
  of residual heritability: need to include `2*kinship`.
- Added an internal function `double_kinship()` to do the work.
  (to take care of the case of the "loco" method (leave one chromosome
  out) and of having pre-computed the eigen decomposition).
- Also added a bit of detail in the help files for `scan1` and `est_herit`.
