### PR TITLE
added a check for mclapply failure

### DIFF
--- a/R/cluster_util.R
+++ b/R/cluster_util.R
@@ -45,6 +45,10 @@ cluster_lapply <-
         return( parallel::parLapply(cores, ...) )
     } else {
         if(cores==1) return( lapply(...) )
-        return( parallel::mclapply(..., mc.cores=cores) )
+        output = parallel::mclapply(..., mc.cores=cores)
+        if (is.list(output) & all(sapply(output, is.null))) {
+          warning("All cluster outputs are NULL, maybe `mclapply` memory problem?")
+        }
+        return( output )
     }
 }


### PR DESCRIPTION
Hi Karl,

I am suggesting to throw a warning if `mclapply` outputs a list with NULLs only. This happens if `mclapply` fails because of memory problems.

Petr
