### PR TITLE
In scan1 and scan1blup, stop with error if cluster_lapply returns NULLs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: qtl2scan
-Version: 0.4-24
+Version: 0.4-25
 Date: 2016-12-21
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a

--- a/R/cluster_util.R
+++ b/R/cluster_util.R
@@ -45,10 +45,6 @@ cluster_lapply <-
         return( parallel::parLapply(cores, ...) )
     } else {
         if(cores==1) return( lapply(...) )
-        output = parallel::mclapply(..., mc.cores=cores)
-        if (is.list(output) & all(sapply(output, is.null))) {
-          warning("All cluster outputs are NULL, maybe `mclapply` memory problem?")
-        }
-        return( output )
+        return( parallel::mclapply(..., mc.cores=cores) )
     }
 }

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -275,6 +275,11 @@ scan1 <-
         # calculations in parallel
         list_result <- cluster_lapply(cores, run_indexes, by_group_func)
 
+        # check for problems (if clusters run out of memory, they'll return NULL)
+        result_is_null <- vapply(list_result, is.null, TRUE)
+        if(any(result_is_null))
+            stop("cluster problem: returned ", sum(result_is_null), " NULLs.")
+
         # reorganize results
         for(i in run_indexes) {
             chr <- run_batches$chr[i]

--- a/R/scan1_pg.R
+++ b/R/scan1_pg.R
@@ -187,6 +187,11 @@ calc_hsq_clean <-
     # now do the work
     result <- cluster_lapply(cores, seq(along=Ke), by_chr_func)
 
+    # check for problems (if clusters run out of memory, they'll return NULL)
+    result_is_null <- vapply(result, is.null, TRUE)
+    if(any(result_is_null))
+        stop("cluster problem: returned ", sum(result_is_null), " NULLs.")
+
     # re-arrange results
     hsq <- matrix(unlist(lapply(result, function(a) a$hsq)), byrow=TRUE,
                   ncol=nphe)
@@ -273,6 +278,11 @@ scan1_pg_clean <-
 
     # now do the work
     lod_list <- cluster_lapply(cores, seq(along=batches$chr), by_batch_func)
+
+    # check for problems (if clusters run out of memory, they'll return NULL)
+    result_is_null <- vapply(lod_list, is.null, TRUE)
+    if(any(result_is_null))
+        stop("cluster problem: returned ", sum(result_is_null), " NULLs.")
 
     npos_by_chr <- vapply(genoprobs$probs, function(a) dim(a)[3], 1)
     totpos <- sum(npos_by_chr)

--- a/R/scan1blup.R
+++ b/R/scan1blup.R
@@ -184,6 +184,12 @@ scan1blup <-
         else SE <- NULL
     } else {
         result <- cluster_lapply(cores, seq(along=batches), by_group_func)
+
+        # check for problems (if clusters run out of memory, they'll return NULL)
+        result_is_null <- vapply(result, is.null, TRUE)
+        if(any(result_is_null))
+            stop("cluster problem: returned ", sum(result_is_null), " NULLs.")
+
         SE <- coef <- matrix(nrow=n_pos,ncol=nrow(result[[1]]$coef))
         for(i in seq(along=result)) {
             coef[batches[[i]],] <- t(result[[i]]$coef)

--- a/R/scan1blup_pg.R
+++ b/R/scan1blup_pg.R
@@ -136,6 +136,12 @@ scan1blup_pg <-
         coef <- t(result$coef)
     } else {
         result <- cluster_lapply(cores, seq(along=batches), by_group_func)
+
+        # check for problems (if clusters run out of memory, they'll return NULL)
+        result_is_null <- vapply(result, is.null, TRUE)
+        if(any(result_is_null))
+            stop("cluster problem: returned ", sum(result_is_null), " NULLs.")
+
         SE <- coef <- matrix(nrow=n_pos,ncol=nrow(result[[1]]$coef))
         for(i in seq(along=result)) {
             coef[batches[[i]],] <- t(result[[i]]$coef)


### PR DESCRIPTION
 - Petr Simecek noted that if their cluster runs out of memory, the
   cluster_lapply function will return a list of NULLs, which returns in
   a cryptic error in later code.

 - Added checks for NULLs in the returned results and stops with an
   error if there is a problem.

- This is a revised fix of PR #79 