### PR TITLE
dim.calc_genoprob and dimnames.calc_genoprob for use with qtl2feather

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.5-6
-Date: 2017-03-17
+Version: 0.5-7
+Date: 2017-03-21
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a
     reimplementation of the R/qtl package to better handle

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+## qtl2scan 0.5-7 (2017-03-21)
+
+### New features
+
+- Added `dim.calc_genoprob` and `dimnames.calcgenoprob`, from
+  [Brian Yandell](https://github.com/byandell), for use with
+  [qtl2feather](https://github.com/byandell/qtl2feather), which uses
+  [feather](https://github.com/wesm/feather) to store
+  genotype probabilities in a file (to save memory).
+
+- In precess of revising various functions to use qtl2feather,
+  particularly in grabbing dimnames (with the above functions), but
+  also to avoid `seq(along=genoprobs)` and instead use
+  `seq_len(length(genoprobs))`.
+
+
 ## qtl2scan 0.5-6 (2017-03-17)
 
 ### New features

--- a/R/batch_cols.R
+++ b/R/batch_cols.R
@@ -42,7 +42,7 @@ batch_cols <-
     if(any(one_na)) {
         wh <- apply(mat[,one_na,drop=FALSE], 2, which)
         spl <- split(which(one_na), wh)
-        part2 <- lapply(seq(along=spl), function(i)
+        part2 <- lapply(seq_along(spl), function(i)
                         list(cols=as.numeric(spl[[i]]),
                              omit=as.numeric(names(spl)[i])))
 

--- a/R/cbind_expand.R
+++ b/R/cbind_expand.R
@@ -16,7 +16,7 @@ cbind_expand <-
     nrow <- vapply(input, nrow, 1)
     max_nrow <- max(nrow)
 
-    for(i in seq(along=input)) {
+    for(i in seq_along(input)) {
         rownames(input[[i]]) <- NULL # strip off the rownames
         if(nrow[i] < max_nrow) { # need to pad
             new_rows <- matrix(NA, ncol=ncol(input[[i]]), nrow=max_nrow - nrow[i])

--- a/R/dims_calc_genoprob.R
+++ b/R/dims_calc_genoprob.R
@@ -1,0 +1,17 @@
+# dimensions of calc_genoprob object
+dim.calc_genoprob <-
+    function(x)
+{
+  vapply(x, dim, rep(1,3))
+}
+
+# dimnames of calc_genoprob object
+dimnames.calc_genoprob <-
+    function(x)
+{
+  dnames <- lapply(x, dimnames)
+
+  list(ind = dnames[[1]][[1]],
+       gen = lapply(dnames, '[[', 2),
+       mar = lapply(dnames, '[[', 3))
+}

--- a/R/est_herit.R
+++ b/R/est_herit.R
@@ -118,7 +118,7 @@ est_herit <-
     n <- nullLL <- hsq
 
     # loop over batches of phenotypes with the same pattern of NAs
-    for(batch in seq(along=phe_batches)) {
+    for(batch in seq_along(phe_batches)) {
 
         # info about batch
         omit <- phe_batches[[batch]]$omit # ind to omit

--- a/R/find_peaks.R
+++ b/R/find_peaks.R
@@ -158,12 +158,12 @@ find_peaks <-
 
     # split lod scores by column and by chromosome
     lod <- as.list(as.data.frame(unclass(scan1_output)))
-    chr <- rep(seq(along=map), vapply(map, length, 1))
+    chr <- rep(seq_along(map), vapply(map, length, 1))
     lod <- lapply(lod, split, chr)
 
     # batch info for parallel-processing
-    batch <- cbind(rep(seq(along=lod), vapply(lod, length, 1)),
-                   unlist(lapply(lod, function(a) seq(along=a))))
+    batch <- cbind(rep(seq_along(lod), vapply(lod, length, 1)),
+                   unlist(lapply(lod, function(a) seq_along(a))))
     dimnames(batch) <- NULL
     batch_index <- 1:nrow(batch)
 
@@ -201,7 +201,7 @@ find_peaks <-
                    chr=rep(names(map)[chr],n_peaks),
                    pos=peak_pos,
                    lod=peak_lod,
-                   row.names=seq(along=peaks),
+                   row.names=seq_along(peaks),
                    stringsAsFactors=FALSE)
     }
 

--- a/R/find_peaks_and_bayesint.R
+++ b/R/find_peaks_and_bayesint.R
@@ -39,12 +39,12 @@ find_peaks_and_bayesint <-
 
     # split lod scores by column and by chromosome
     lod <- as.list(as.data.frame(unclass(scan1_output)))
-    chr <- rep(seq(along=map), vapply(map, length, 1))
+    chr <- rep(seq_along(map), vapply(map, length, 1))
     lod <- lapply(lod, split, chr)
 
     # batch info for parallel-processing
-    batch <- cbind(rep(seq(along=lod), vapply(lod, length, 1)),
-                   unlist(lapply(lod, function(a) seq(along=a))))
+    batch <- cbind(rep(seq_along(lod), vapply(lod, length, 1)),
+                   unlist(lapply(lod, function(a) seq_along(a))))
     dimnames(batch) <- NULL
     batch_index <- 1:nrow(batch)
 
@@ -94,7 +94,7 @@ find_peaks_and_bayesint <-
                    lod=peak_lod,
                    ci_lo=ci_lo,
                    ci_hi=ci_hi,
-                   row.names=seq(along=peaks),
+                   row.names=seq_along(peaks),
                    stringsAsFactors=FALSE)
     }
 

--- a/R/find_peaks_and_lodint.R
+++ b/R/find_peaks_and_lodint.R
@@ -42,12 +42,12 @@ find_peaks_and_lodint <-
 
     # split lod scores by column and by chromosome
     lod <- as.list(as.data.frame(unclass(scan1_output)))
-    chr <- rep(seq(along=map), vapply(map, length, 1))
+    chr <- rep(seq_along(map), vapply(map, length, 1))
     lod <- lapply(lod, split, chr)
 
     # batch info for parallel-processing
-    batch <- cbind(rep(seq(along=lod), vapply(lod, length, 1)),
-                   unlist(lapply(lod, function(a) seq(along=a))))
+    batch <- cbind(rep(seq_along(lod), vapply(lod, length, 1)),
+                   unlist(lapply(lod, function(a) seq_along(a))))
     dimnames(batch) <- NULL
     batch_index <- 1:nrow(batch)
 
@@ -97,7 +97,7 @@ find_peaks_and_lodint <-
                    lod=peak_lod,
                    ci_lo=ci_lo,
                    ci_hi=ci_hi,
-                   row.names=seq(along=peaks),
+                   row.names=seq_along(peaks),
                    stringsAsFactors=FALSE)
     }
 
@@ -127,7 +127,7 @@ expand_interval_to_markers <-
     pmar_pattern <- "^c.+\\.loc-*[0-9]+(\\.[0-9]+)*$"
     pmar <- grepl(pmar_pattern, mn)
 
-    mar_index <- seq(along=map)[!pmar]
+    mar_index <- seq_along(map)[!pmar]
 
     lo_index <- ci_index[1]
     hi_index <- ci_index[2]

--- a/R/genoprob_col2drop.R
+++ b/R/genoprob_col2drop.R
@@ -19,10 +19,10 @@ genoprobs_col2drop <-
             return(result)
         }
         else {
-            result <- lapply(seq(along=probs), function(a) numeric(0))
+            result <- lapply(seq_len(length(probs)), function(a) numeric(0))
             names(result) <- names(probs)
 
-            for(i in seq(length(probs)))
+            for(i in seq_len(length(probs)))
               result[[i]] <- genoprobs_col2drop(probs[[i]])
 
             return(result)

--- a/R/genoprob_col2drop.R
+++ b/R/genoprob_col2drop.R
@@ -5,11 +5,11 @@ genoprobs_col2drop <-
     function(probs, Xonly=TRUE, tol=1e-8)
 {
     if(is.list(probs)) { # proper calc_genoprob object, hopefully
+        is_x_chr <- attr(probs, "is_x_chr")
         if(Xonly) {
             result <- lapply(seq(along=probs), function(a) numeric(0))
             names(result) <- names(probs)
 
-            is_x_chr <- attr(probs, "is_x_chr")
             if(is.null(is_x_chr) || !any(is_x_chr)) return(result) # no X chr
 
             w <- which(is_x_chr)
@@ -18,7 +18,10 @@ genoprobs_col2drop <-
             return(result)
         }
         else {
-            return(lapply(probs, genoprobs_col2drop))
+            w <- which(!is_x_chr)
+            for(i in w)
+              result[[i]] <- genoprobs_col2drop(probs[[i]])
+            return(result)
         }
     }
 

--- a/R/genoprob_col2drop.R
+++ b/R/genoprob_col2drop.R
@@ -7,7 +7,7 @@ genoprobs_col2drop <-
     if(is.list(probs)) { # proper calc_genoprob object, hopefully
         is_x_chr <- attr(probs, "is_x_chr")
         if(Xonly) {
-            result <- lapply(seq(along=probs), function(a) numeric(0))
+            result <- lapply(seq_len(length(probs)), function(a) numeric(0))
             names(result) <- names(probs)
 
             if(is.null(is_x_chr) || !any(is_x_chr)) return(result) # no X chr

--- a/R/genoprob_col2drop.R
+++ b/R/genoprob_col2drop.R
@@ -15,12 +15,16 @@ genoprobs_col2drop <-
             w <- which(is_x_chr)
             for(i in w)
                 result[[i]] <- genoprobs_col2drop(probs[[i]])
+
             return(result)
         }
         else {
-            w <- which(!is_x_chr)
-            for(i in w)
+            result <- lapply(seq(along=probs), function(a) numeric(0))
+            names(result) <- names(probs)
+
+            for(i in seq(length(probs)))
               result[[i]] <- genoprobs_col2drop(probs[[i]])
+
             return(result)
         }
     }

--- a/R/genoprob_to_snpprob.R
+++ b/R/genoprob_to_snpprob.R
@@ -110,7 +110,7 @@ genoprob_to_snpprob <-
         ### loop over chromosomes, using recursion
         results <- vector("list", length(uchr))
         names(results) <- uchr
-        for(i in seq(along=uchr))
+        for(i in seq_along(uchr))
             results[[i]] <- genoprob_to_snpprob(genoprobs, snpinfo_spl[[i]])[[1]]
 
         ### add attributes

--- a/R/get_common_ids.R
+++ b/R/get_common_ids.R
@@ -38,7 +38,7 @@ get_common_ids <-
 
     # find the IDs in common across all
     id <- NULL
-    for(i in seq(along=args)) {
+    for(i in seq_along(args)) {
         if(is.null(args[[i]])) next
 
         if(is.matrix(args[[i]]) || is.data.frame(args[[i]]) || is.array(args[[i]])) {

--- a/R/index_snps.R
+++ b/R/index_snps.R
@@ -90,7 +90,7 @@ index_snps <-
         snpinfo_spl <- split(snpinfo, chr)
 
         ### loop over chromosomes, using recursion
-        for(i in seq(along=uchr))
+        for(i in seq_along(uchr))
             snpinfo_spl[[i]] <- index_snps(map, snpinfo_spl[[i]])
 
         # combine the results

--- a/R/is_same.R
+++ b/R/is_same.R
@@ -7,7 +7,7 @@ is_same <-
 
     if(is.list(a) && is.list(b)) {
         if(length(a) != length(b)) return(FALSE)
-        for(i in seq(along=a))
+        for(i in seq_along(a))
             if(!is_same(a[[i]], b[[i]])) return(FALSE)
         return(TRUE)
     }

--- a/R/pick_marker_subset.R
+++ b/R/pick_marker_subset.R
@@ -54,7 +54,7 @@ pick_marker_subset <-
                any(vapply(weights, length, 1) != vapply(map, length, 1)))
                 stop("map and weights are different shapes")
         }
-        for(i in seq(along=map)) {
+        for(i in seq_along(map)) {
             if(is.null(weights)) wts <- rep(1, length(map[[i]]))
             else wts <- weights[[i]]
 

--- a/R/rcbind_scan1perm.R
+++ b/R/rcbind_scan1perm.R
@@ -67,7 +67,7 @@ rbind.scan1perm <-
         n_col <- vapply(dots, ncol, 1)
         if(length(unique(n_col)) != 1)
             stop("Inputs must all have the same number of columns.")
-        for(i in seq(along=dots)[-1]) {
+        for(i in seq_along(dots)[-1]) {
             if(!all(colnames(dots[[1]]) == colnames(dots[[i]])))
                 warning("Inputs have different column names; using those from the first input.")
         }
@@ -89,7 +89,7 @@ rbind.scan1perm <-
         n_colX <- vapply(dots, function(a) ncol(a$X), 1)
         if(length(unique(c(n_colA, n_colX))) != 1)
             stop("Inputs must all have the same number of columns.")
-        for(i in seq(along=dots)[-1]) {
+        for(i in seq_along(dots)[-1]) {
             if(!all(colnames(dots[[1]]$A) == colnames(dots[[i]]$A)) ||
                !all(colnames(dots[[1]]$X) == colnames(dots[[i]]$X)))
                 warning("Inputs have different column names; using those from the first input.")
@@ -112,7 +112,7 @@ rbind.scan1perm <-
             if(any(vapply(is_x_chr, length, 1) != 2) ||
                any(vapply(is_x_chr, function(a) any(sort(names(a)) != c("A", "X")), TRUE)))
                 stop('is_x_chr attributes should be length 2 vectors with names "A" and "X"')
-            for(i in seq(along=is_x_chr)[-1]) {
+            for(i in seq_along(is_x_chr)[-1]) {
                 if(is_x_chr[[1]]["A"] != is_x_chr[[i]]["A"] ||
                    is_x_chr[[1]]["X"] != is_x_chr[[i]]["X"])
                     stop("is_x_chr attributes differ")
@@ -241,7 +241,7 @@ cbind.scan1perm <-
             if(any(vapply(is_x_chr, length, 1) != 2) ||
                any(vapply(is_x_chr, function(a) any(sort(names(a)) != c("A", "X")), TRUE)))
                 stop('is_x_chr attributes should be length 2 vectors with names "A" and "X"')
-            for(i in seq(along=is_x_chr)[-1]) {
+            for(i in seq_along(is_x_chr)[-1]) {
                 if(is_x_chr[[1]]["A"] != is_x_chr[[i]]["A"] ||
                    is_x_chr[[1]]["X"] != is_x_chr[[i]]["X"])
                     stop("is_x_chr attributes differ")

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -239,7 +239,7 @@ scan1 <-
     }
 
     # number of markers/pseudomarkers by chromosome, and their indexes to result matrix
-    npos_by_chr <- vapply(genoprobs, function(a) dim(a)[3], 1)
+    npos_by_chr <- dim(genoprobs)[3,]
     totpos <- sum(npos_by_chr)
     pos_index <- split(1:totpos, rep(seq(along=genoprobs), npos_by_chr))
 
@@ -284,7 +284,7 @@ scan1 <-
         }
     }
 
-    pos_names <- unlist(lapply(genoprobs, function(a) dimnames(a)[[3]]))
+    pos_names <- unlist(dimnames(genoprobs)[[3]])
     names(pos_names) <- NULL # this is just annoying
     dimnames(result) <- list(pos_names, colnames(pheno))
 

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -190,8 +190,8 @@ scan1 <-
     }
 
     # batches for analysis, to allow parallel analysis
-    run_batches <- data.frame(chr=rep(seq(along=genoprobs), length(phe_batches)),
-                              phe_batch=rep(seq(along=phe_batches), each=length(genoprobs)))
+    run_batches <- data.frame(chr=rep(seq_len(length(genoprobs)), length(phe_batches)),
+                              phe_batch=rep(seq_along(phe_batches), each=length(genoprobs)))
     run_indexes <- 1:(length(genoprobs)*length(phe_batches))
 
     # the function that does the work
@@ -241,7 +241,7 @@ scan1 <-
     # number of markers/pseudomarkers by chromosome, and their indexes to result matrix
     npos_by_chr <- dim(genoprobs)[3,]
     totpos <- sum(npos_by_chr)
-    pos_index <- split(1:totpos, rep(seq(along=genoprobs), npos_by_chr))
+    pos_index <- split(1:totpos, rep(seq_len(length(genoprobs)), npos_by_chr))
 
     # object to contain the LOD scores; also attr to contain sample size
     result <- matrix(nrow=totpos, ncol=ncol(pheno))

--- a/R/scan1_pg.R
+++ b/R/scan1_pg.R
@@ -76,7 +76,7 @@ scan1_pg <-
     # number of markers/pseudomarkers by chromosome, and their indexes to result matrix
     npos_by_chr <- dim(genoprobs)[3,]
     totpos <- sum(npos_by_chr)
-    pos_index <- split(1:totpos, rep(seq(along=genoprobs), npos_by_chr))
+    pos_index <- split(1:totpos, rep(seq_len(length(genoprobs)), npos_by_chr))
     pos_names <- unlist(dimnames(genoprobs)[[3]])
     names(pos_names) <- NULL # this is just annoying
 
@@ -94,7 +94,7 @@ scan1_pg <-
     n <- rep(NA, ncol(pheno)); names(n) <- colnames(pheno)
 
     # loop over batches of phenotypes with the same pattern of NAs
-    for(batch in seq(along=phe_batches)) {
+    for(batch in seq_along(phe_batches)) {
 
         # info about batch
         omit <- phe_batches[[batch]]$omit # ind to omit
@@ -175,7 +175,7 @@ calc_hsq_clean <-
         }
 
     # now do the work
-    result <- cluster_lapply(cores, seq(along=Ke), by_chr_func)
+    result <- cluster_lapply(cores, seq_along(Ke), by_chr_func)
 
     # check for problems (if clusters run out of memory, they'll return NULL)
     result_is_null <- vapply(result, is.null, TRUE)
@@ -207,7 +207,7 @@ scan1_pg_clean <-
         else no_x <- FALSE
     } else loco <- TRUE
 
-    batches <- list(chr=rep(seq(along=genoprobs), ncol(pheno)),
+    batches <- list(chr=rep(seq_len(length(genoprobs)), ncol(pheno)),
                     phecol=rep(1:ncol(pheno), each=length(genoprobs)))
 
     # function that does the work
@@ -267,7 +267,7 @@ scan1_pg_clean <-
         }
 
     # now do the work
-    lod_list <- cluster_lapply(cores, seq(along=batches$chr), by_batch_func)
+    lod_list <- cluster_lapply(cores, seq_along(batches$chr), by_batch_func)
 
     # check for problems (if clusters run out of memory, they'll return NULL)
     result_is_null <- vapply(lod_list, is.null, TRUE)
@@ -276,11 +276,11 @@ scan1_pg_clean <-
 
     npos_by_chr <- dim(genoprobs)[3,]
     totpos <- sum(npos_by_chr)
-    pos_index <- split(1:totpos, rep(seq(along=genoprobs), npos_by_chr))
+    pos_index <- split(1:totpos, rep(seq_len(length(genoprobs)), npos_by_chr))
 
     # to contain the results
     result <- matrix(nrow=totpos, ncol=ncol(pheno))
-    for(batch in seq(along=batches$chr)) {
+    for(batch in seq_along(batches$chr)) {
         chr <- batches$chr[batch]
         phecol <- batches$phecol[batch]
         result[pos_index[[chr]], phecol] <- lod_list[[batch]]

--- a/R/scan1_pg.R
+++ b/R/scan1_pg.R
@@ -74,10 +74,10 @@ scan1_pg <-
     }
 
     # number of markers/pseudomarkers by chromosome, and their indexes to result matrix
-    npos_by_chr <- vapply(genoprobs, function(a) dim(a)[3], 1)
+    npos_by_chr <- dim(genoprobs)[3,]
     totpos <- sum(npos_by_chr)
     pos_index <- split(1:totpos, rep(seq(along=genoprobs), npos_by_chr))
-    pos_names <- unlist(lapply(genoprobs, function(a) dimnames(a)[[3]]))
+    pos_names <- unlist(dimnames(genoprobs)[[3]])
     names(pos_names) <- NULL # this is just annoying
 
     # to contain the results
@@ -274,7 +274,7 @@ scan1_pg_clean <-
     if(any(result_is_null))
         stop("cluster problem: returned ", sum(result_is_null), " NULLs.")
 
-    npos_by_chr <- vapply(genoprobs, function(a) dim(a)[3], 1)
+    npos_by_chr <- dim(genoprobs)[3,]
     totpos <- sum(npos_by_chr)
     pos_index <- split(1:totpos, rep(seq(along=genoprobs), npos_by_chr))
 

--- a/R/scan1blup.R
+++ b/R/scan1blup.R
@@ -181,7 +181,7 @@ scan1blup <-
         if(se) SE <- t(result$SE)
         else SE <- NULL
     } else {
-        result <- cluster_lapply(cores, seq(along=batches), by_group_func)
+        result <- cluster_lapply(cores, seq_along(batches), by_group_func)
 
         # check for problems (if clusters run out of memory, they'll return NULL)
         result_is_null <- vapply(result, is.null, TRUE)
@@ -189,7 +189,7 @@ scan1blup <-
             stop("cluster problem: returned ", sum(result_is_null), " NULLs.")
 
         SE <- coef <- matrix(nrow=n_pos,ncol=nrow(result[[1]]$coef))
-        for(i in seq(along=result)) {
+        for(i in seq_along(result)) {
             coef[batches[[i]],] <- t(result[[i]]$coef)
             if(se) SE[batches[[i]],] <- t(result[[i]]$SE)
             else SE <- NULL

--- a/R/scan1blup_pg.R
+++ b/R/scan1blup_pg.R
@@ -133,7 +133,7 @@ scan1blup_pg <-
         else SE <- NULL
         coef <- t(result$coef)
     } else {
-        result <- cluster_lapply(cores, seq(along=batches), by_group_func)
+        result <- cluster_lapply(cores, seq_along(batches), by_group_func)
 
         # check for problems (if clusters run out of memory, they'll return NULL)
         result_is_null <- vapply(result, is.null, TRUE)
@@ -141,7 +141,7 @@ scan1blup_pg <-
             stop("cluster problem: returned ", sum(result_is_null), " NULLs.")
 
         SE <- coef <- matrix(nrow=n_pos,ncol=nrow(result[[1]]$coef))
-        for(i in seq(along=result)) {
+        for(i in seq_along(result)) {
             coef[batches[[i]],] <- t(result[[i]]$coef)
             if(se) SE[batches[[i]],] <- t(result[[i]]$SE)
             else SE <- NULL

--- a/R/scan1perm.R
+++ b/R/scan1perm.R
@@ -280,8 +280,8 @@ scan1perm_nocovar <-
     }
 
     # batches for analysis, to allow parallel analysis
-    run_batches <- data.frame(chr=rep(seq(along=genoprobs), length(phe_batches)),
-                              phe_batch=rep(seq(along=phe_batches), each=length(genoprobs)))
+    run_batches <- data.frame(chr=rep(seq_len(length(genoprobs)), length(phe_batches)),
+                              phe_batch=rep(seq_along(phe_batches), each=length(genoprobs)))
 
     run_indexes <- 1:(length(genoprobs)*length(phe_batches))
 
@@ -338,7 +338,7 @@ scan1perm_nocovar <-
         phebatch <- phe_batches[[run_batches$phe_batch[i]]]
         permbatch <- perm_batches[[run_batches$phe_batch[i]]]
 
-        for(j in seq(along=phebatch))
+        for(j in seq_along(phebatch))
             result[chr,permbatch[j], phebatch[j]] <- list_result[[i]][j]
 
     }
@@ -385,8 +385,8 @@ scan1perm_covar <-
     }
 
     # batches for analysis, to allow parallel analysis
-    run_batches <- data.frame(chr=rep(seq(along=genoprobs), length(phe_batches)*n_perm),
-                              phe_batch=rep(seq(along=phe_batches), each=length(genoprobs)*n_perm),
+    run_batches <- data.frame(chr=rep(seq_len(length(genoprobs)), length(phe_batches)*n_perm),
+                              phe_batch=rep(seq_along(phe_batches), each=length(genoprobs)*n_perm),
                               perm_batch=rep(rep(1:n_perm, each=length(genoprobs), length(phe_batches))))
 
     run_indexes <- 1:(length(genoprobs)*length(phe_batches)*n_perm)
@@ -489,11 +489,11 @@ gen_strat_perm <-
             strat_numeric <- match(perm_strata, u)-1
 
             return(permute_nvector_stratified(n_perm,
-                                              seq(along=ind2keep),
+                                              seq_along(ind2keep),
                                               strat_numeric,
                                               length(u)))
         }
     }
 
-    permute_nvector(n_perm, seq(along=ind2keep))
+    permute_nvector(n_perm, seq_along(ind2keep))
 }

--- a/R/scan1perm_pg.R
+++ b/R/scan1perm_pg.R
@@ -46,7 +46,7 @@ scan1perm_pg <-
 
         decomp_kinship(subset_kinship(kinship, ind=these2keep), cores=1)
     }
-    kinship_list <- cluster_lapply(cores, seq(along=uindex_batches), decomp_func)
+    kinship_list <- cluster_lapply(cores, seq_along(uindex_batches), decomp_func)
 
     ## null results
     null_by_batch_func <- function(i) {
@@ -68,14 +68,14 @@ scan1perm_pg <-
         n_chr <- length(is_x_chr)
         if(nrow(result$hsq) != n_chr) {
             if(nrow(result$hsq)==1) {
-                for(i in seq(along=result))
+                for(i in seq_along(result))
                     result[[i]] <- matrix(rep(result[[i]], n_chr), byrow=TRUE, nrow=n_chr)
             }
             else if(nrow(result$hsq)==2) {
-                for(i in seq(along=result)) {
+                for(i in seq_along(result)) {
                     tmp <- result[[i]]
                     result[[i]] <- matrix(nrow=n_chr, ncol=ncol(tmp))
-                    for(j in seq(along=is_x_chr)) {
+                    for(j in seq_along(is_x_chr)) {
                         if(is_x_chr[j])
                             result[[i]][j,] <- tmp[2,]
                         else
@@ -87,11 +87,11 @@ scan1perm_pg <-
 
         result
     }
-    nullresult <- cluster_lapply(cores, seq(along=phe_batches), null_by_batch_func)
+    nullresult <- cluster_lapply(cores, seq_along(phe_batches), null_by_batch_func)
 
     # batches for analysis, to allow parallel analysis
-    run_batches <- data.frame(chr=rep(seq(along=genoprobs), length(phe_batches)*n_perm),
-                              phe_batch=rep(seq(along=phe_batches), each=length(genoprobs)*n_perm),
+    run_batches <- data.frame(chr=rep(seq_len(length(genoprobs)), length(phe_batches)*n_perm),
+                              phe_batch=rep(seq_along(phe_batches), each=length(genoprobs)*n_perm),
                               perm_batch=rep(rep(1:n_perm, each=length(genoprobs), length(phe_batches))))
 
     run_indexes <- 1:(length(genoprobs)*length(phe_batches)*n_perm)

--- a/R/subset_scan1.R
+++ b/R/subset_scan1.R
@@ -65,7 +65,7 @@ subset_scan1 <-
             x_mnames <- rownames(x)
         }
         if(!all(map_mnames %in% x_mnames)) {
-            for(i in seq(along=map)) {
+            for(i in seq_along(map)) {
                 mn <- names(map[[i]])
                 map[[i]] <- map[[i]][mn %in% x_mnames]
             }

--- a/R/summary_scan1perm.R
+++ b/R/summary_scan1perm.R
@@ -106,7 +106,7 @@ summary_scan1perm <-
 
         result <- list(A=apply(object$A, 2, quantile, 1-alphaA, na.rm=TRUE),
                        X=apply(object$X, 2, quantile, 1-alphaX, na.rm=TRUE))
-        for(i in seq(along=result)) {
+        for(i in seq_along(result)) {
             if(!is.matrix(result[[i]])) {
                 result[[i]] <- matrix(result[[i]], nrow=1)
                 colnames(result[[i]]) <- colnames(object[[i]])

--- a/R/top_snps.R
+++ b/R/top_snps.R
@@ -141,7 +141,7 @@ snpinfo_to_map <-
     map <- split(snpinfo$pos, chr)
     snp <- split(snpinfo$snp, chr)
     index <- split(snpinfo$index, chr)
-    for(i in seq(along=map)) {
+    for(i in seq_along(map)) {
         u <- unique(index[[i]])
         map[[i]] <- map[[i]][u]
         names(map[[i]]) <- snp[[i]][u]
@@ -157,7 +157,7 @@ rev_snp_index <-
     function(snpinfo)
 {
     index_spl <- split(1:nrow(snpinfo), snpinfo$index)
-    revindex <- rep(seq(along=index_spl), vapply(index_spl, length, 1))
+    revindex <- rep(seq_along(index_spl), vapply(index_spl, length, 1))
     revindex[unlist(index_spl)] <- revindex
 
     revindex

--- a/tests/testthat/test-scan1coef.R
+++ b/tests/testthat/test-scan1coef.R
@@ -189,7 +189,7 @@ test_that("scan1coef for backcross, with contrasts", {
     p <- p %*% contrasts
     dim(p) <- dim(prob)
     prob <- p
-    dimnames(prob) <- list(rownames(prob2), dimnames(prob2)[[3]], colnames(contrasts))
+    dimnames(prob) <- list(rownames(prob2), dimnames(prob2[[1]])[[3]], colnames(contrasts))
 
     posnames <- dimnames(prob2[[1]])[[3]]
 


### PR DESCRIPTION
- Added `dim.calc_genoprob` and `dimnames.calcgenoprob`, from [Brian Yandell](https://github.com/byandell), for use with [qtl2feather](https://github.com/byandell/qtl2feather), which uses [feather](https://github.com/wesm/feather) to store genotype probabilities in a file (to save memory).

- Need to revise various functions to use qtl2feather, particularly in grabbing dimnames (with the above functions), but also to avoid `seq(along=genoprobs)` and instead use `seq_len(length(genoprobs))`.