### PR TITLE
Align scan1 output with map in max_scan1(), find_peaks(), ...

### DIFF
--- a/R/align_scan1_map.R
+++ b/R/align_scan1_map.R
@@ -13,6 +13,9 @@ align_scan1_map <-
        all(scan1_names == map_names))
         return(list(scan1_output=scan1_output, map=map))
 
+    if(!any(scan1_names %in% map_names))
+        stop("scan1 output and map have no markers in common")
+
     # subset scan1_output to markers in the map
     #    and use order as in map
     if(any(!(scan1_names %in% map_names))) {

--- a/R/align_scan1_map.R
+++ b/R/align_scan1_map.R
@@ -1,0 +1,42 @@
+# align scan1 output with a map
+align_scan1_map <-
+    function(scan1_output, map)
+{
+    if(!is.list(map)) stop("map should be a list")
+
+    scan1_names <- rownames(scan1_output)
+    map_names <- map2markernames(map)
+    map_chr <- map2chr(map)
+
+    # perfectly fine
+    if(length(scan1_names) == length(map_names) &&
+       all(scan1_names == map_names))
+        return(list(scan1_output=scan1_output, map=map))
+
+    # subset scan1_output to markers in the map
+    #    and use order as in map
+    if(any(!(scan1_names %in% map_names))) {
+        scan1_attr <- attributes(scan1_output)
+        names_ordered <- map_names[map_names %in% scan1_names]
+        scan1_output <- scan1_output[names_ordered,,drop=FALSE]
+        for(a in c("SE", "sample_size", "hsq", "class"))
+            attr(scan1_output, a) <- scan1_attr[[a]]
+        scan1_names <- rownames(scan1_output)
+    }
+
+    # subset map to markers in scan1_output
+    if(any(!(map_names %in% scan1_names))) {
+        map_attr <- attributes(map)
+        keep <- map_names %in% scan1_names
+        uchr <- unique(map_chr[keep])
+        map <- map[uchr]
+        if("is_x_chr" %in% names(map_attr))
+            map_attr$is_x_chr <- map_attr$is_x_chr[uchr]
+        for(i in seq_along(map))
+            map[[i]] <- map[[i]][names(map[[i]]) %in% scan1_names]
+        for(a in c("is_x_chr", "class"))
+            attr(map, a) <- map_attr[[a]]
+    }
+
+    list(scan1_output=scan1_output, map=map)
+}

--- a/R/bayes_int.R
+++ b/R/bayes_int.R
@@ -72,6 +72,11 @@ bayes_int <-
     function(scan1_output, map, chr, lodcolumn=1, threshold=0,
              peakdrop=Inf, prob=0.95, expand2markers=TRUE)
 {
+    # align scan1_output and map
+    tmp <- align_scan1_map(scan1_output, map)
+    scan1_output <- tmp$scan1
+    map <- tmp$map
+
     if(nrow(scan1_output) != length(unlist(map)))
         stop("nrow(scan1_output) [", nrow(scan1_output), "] != number of positions in map [",
              length(unlist(map)), "]")

--- a/R/find_peaks.R
+++ b/R/find_peaks.R
@@ -114,6 +114,11 @@ find_peaks <-
              thresholdX=NULL, peakdropX=NULL, dropX=NULL, probX=NULL,
              expand2markers=TRUE, cores=1)
 {
+    # align scan1_output and map
+    tmp <- align_scan1_map(scan1_output, map)
+    scan1_output <- tmp$scan1
+    map <- tmp$map
+
     if(nrow(scan1_output) != length(unlist(map)))
         stop("nrow(scan1_output) [", nrow(scan1_output), "] != number of positions in map [",
              length(unlist(map)), "]")

--- a/R/max_scan1.R
+++ b/R/max_scan1.R
@@ -52,6 +52,11 @@
 max_scan1 <-
     function(scan1_output, map, lodcolumn=1, chr=NULL, na.rm=TRUE, ...)
 {
+    # align scan1_output and map
+    tmp <- align_scan1_map(scan1_output, map)
+    scan1_output <- tmp$scan1
+    map <- tmp$map
+
     if(nrow(scan1_output) != length(unlist(map)))
         stop("nrow(scan1_output) [", nrow(scan1_output), "] != number of positions in map [",
              length(unlist(map)), "]")

--- a/R/subset_scan1.R
+++ b/R/subset_scan1.R
@@ -51,6 +51,13 @@
 subset_scan1 <-
     function(x, map=NULL, chr=NULL, lodcolumn=NULL, ...)
 {
+    # align scan1 output and map
+    if(!is.null(map)) {
+        tmp <- align_scan1_map(x, map)
+        x <- tmp$scan1
+        map <- tmp$map
+    }
+
     x_attr <- attributes(x)
     x_attrnam <- names(x_attr)
     x_class <- class(x)

--- a/tests/testthat/test-align_scan1_map.R
+++ b/tests/testthat/test-align_scan1_map.R
@@ -1,0 +1,51 @@
+context("align_scan1_map")
+
+test_that("align_scan1_map works", {
+
+    library(qtl2geno)
+    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
+
+    # insert pseudomarkers into map
+    map <- insert_pseudomarkers(iron$gmap, step=1)
+
+    # calculate genotype probabilities
+    probs <- calc_genoprob(iron, map, error_prob=0.002)
+
+    # grab phenotypes and covariates; ensure that covariates have names attribute
+    pheno <- iron$pheno[,1]
+    covar <- match(iron$covar$sex, c("f", "m")) # make numeric
+    names(covar) <- rownames(iron$covar)
+
+    Xcovar <- get_x_covar(iron)
+
+    # genome scan
+    out <- scan1(probs, iron$pheno, Xcovar=Xcovar, addcovar=covar)
+
+    # calculate coefficients for chromosome 7
+    coef <- scan1coef(probs[,7], pheno, addcovar=covar)
+
+    # not subseted
+    result <- align_scan1_map(out, map)
+    expect_equal(result$scan1, out)
+    expect_equal(result$map, map)
+
+    # chr 7 for map
+    result <- align_scan1_map(out, map[7])
+    expect_equal( result$scan1, subset(out, map, chr="7") )
+    expect_equal( result$map, map[7] )
+
+    # chr 7 for scan
+    result <- align_scan1_map(subset(out,map,chr="7"), map)
+    expect_equal( result$scan1, subset(out, map, chr="7") )
+    expected_map <- map[7]
+    attr(expected_map, "is_x_chr") <- attr(map, "is_x_chr")[7]
+    expect_equal( result$map, expected_map )
+
+    # coefficients
+    result <- align_scan1_map(coef, map)
+    expect_equal( result$scan1, coef )
+    expected_map <- map[7]
+    attr(expected_map, "is_x_chr") <- attr(map, "is_x_chr")[7]
+    expect_equal( result$map, expected_map )
+
+})

--- a/tests/testthat/test-find_peaks.R
+++ b/tests/testthat/test-find_peaks.R
@@ -107,10 +107,6 @@ test_that("find_peaks works", {
                        ci_lo=c(53.3, 12.1, 39.1, 26.0, 21.5, 39.4, 25.1, 28.3,  9.0, 53.6),
                        ci_hi=c(65.3, 28.1, 53.6, 52.0, 40.4, 49.2, 32.6, 38.3, 17.0, 59.6)))
 
-    # expect error if output and map are not aligned
-    expect_error( find_peaks(subset(out, map, chr="2"), map) )
-    expect_error( find_peaks(out, map[2]) )
-
 })
 
 test_that("lod_int works", {
@@ -136,10 +132,6 @@ test_that("lod_int works", {
     expected4 <- cbind(ci_lo=0.0, pos=13.6, ci_hi=32.7)
     rownames(expected4) <- 1
     expect_equal(lod_int(out, map, 8, 2), expected4)
-
-    # expect error if output and map are not aligned
-    expect_error( lod_int(subset(out, map, chr="2"), map) )
-    expect_error( lod_int(out, map[2]) )
 
 })
 
@@ -167,10 +159,6 @@ test_that("bayes_int works", {
     expected4 <- cbind(ci_lo=0.0, pos=13.6, ci_hi=32.7)
     rownames(expected4) <- 1
     expect_equal(bayes_int(out, map, 8, 2), expected4)
-
-    # expect error if output and map are not aligned
-    expect_error( bayes_int(subset(out, map, chr="2"), map) )
-    expect_error( bayes_int(out, map[2]) )
 
 })
 

--- a/tests/testthat/test-max_scan1.R
+++ b/tests/testthat/test-max_scan1.R
@@ -45,10 +45,6 @@ test_that("max_scan1 works for intercross with two phenotypes", {
     rownames(expected) <- "D2Mit17"
     expect_equal(max(out, map, chr="2"), expected)
 
-    # should throw an error if out and map are not aligned
-    expect_error( max(subset(out, map, chr="2"), map) )
-    expect_error( max(out, map[2]) )
-
 })
 
 test_that("maxlod works for intercross with two phenotypes", {


### PR DESCRIPTION
For functions that take both output from `scan1()` (or `scan1coef()`) and a genetic map, such as `max_scan1()` and `find_peaks()`, added an internal function `align_scan1_map()` that makes sure they are using the same set of markers. 

You then don't need to subset the map when you're dealing with `scan1()` results that are for a single chromosome. 