### PR TITLE
Fix example contrasts for intercross

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.5-16
-Date: 2017-06-16
+Version: 0.5-17
+Date: 2017-06-29
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a
     reimplementation of the R/qtl package to better handle

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## qtl2scan 0.5-16 (2017-06-29)
+
+### Minor changes
+
+- For the example contrasts in `scan1coef`, `scan1blup`, and
+  `fit1`, the contrasts for the additive effect in an intercross
+  should be `(-1,0,1)` not `(-0.5,0,0.5)`. Also fixed in the user
+  guide.
+
+
 ## qtl2scan 0.5-14 (2017-06-05)
 
 ### Minor changes

--- a/R/fit1.R
+++ b/R/fit1.R
@@ -20,7 +20,7 @@
 #' for individual identifiers. Ignored if \code{kinship} is provided.
 #' @param contrasts An optional matrix of genotype contrasts, size
 #' genotypes x genotypes. For an intercross, you might use
-#' \code{cbind(c(1,1,1), c(-0.5, 0, 0.5), c(-0.5, 1, -0.5))} to get
+#' \code{cbind(c(1,1,1), c(-1, 0, 1), c(-0.5, 1, -0.5))} to get
 #' mean, additive effect, and dominance effect. The default is the
 #' identity matrix.
 #' @param model Indicates whether to use a normal model (least

--- a/R/scan1blup.R
+++ b/R/scan1blup.R
@@ -21,7 +21,7 @@
 #' estimate of residual heritability.
 #' @param contrasts An optional matrix of genotype contrasts, size
 #' genotypes x genotypes. For an intercross, you might use
-#' \code{cbind(c(1,0,0), c(-0.5, 0, 0.5), c(-0.5, 1, 0.5))} to get
+#' \code{cbind(c(1,0,0), c(-1, 0, 1), c(-0.5, 1, 0.5))} to get
 #' mean, additive effect, and dominance effect. The default is the
 #' identity matrix.
 #' @param se If TRUE, also calculate the standard errors.

--- a/R/scan1coef.R
+++ b/R/scan1coef.R
@@ -26,7 +26,7 @@
 #' for individual identifiers. Ignored if \code{kinship} is provided.
 #' @param contrasts An optional matrix of genotype contrasts, size
 #' genotypes x genotypes. For an intercross, you might use
-#' \code{cbind(c(1,1,1), c(-0.5, 0, 0.5), c(-0.5, 1, -0.5))} to get
+#' \code{cbind(c(1,1,1), c(-1, 0, 1), c(-0.5, 1, -0.5))} to get
 #' mean, additive effect, and dominance effect. The default is the
 #' identity matrix.
 #' @param model Indicates whether to use a normal model (least

--- a/man/fit1.Rd
+++ b/man/fit1.Rd
@@ -34,7 +34,7 @@ for individual identifiers. Ignored if \code{kinship} is provided.}
 
 \item{contrasts}{An optional matrix of genotype contrasts, size
 genotypes x genotypes. For an intercross, you might use
-\code{cbind(c(1,1,1), c(-0.5, 0, 0.5), c(-0.5, 1, -0.5))} to get
+\code{cbind(c(1,1,1), c(-1, 0, 1), c(-0.5, 1, -0.5))} to get
 mean, additive effect, and dominance effect. The default is the
 identity matrix.}
 

--- a/man/scan1blup.Rd
+++ b/man/scan1blup.Rd
@@ -32,7 +32,7 @@ estimate of residual heritability.}
 
 \item{contrasts}{An optional matrix of genotype contrasts, size
 genotypes x genotypes. For an intercross, you might use
-\code{cbind(c(1,0,0), c(-0.5, 0, 0.5), c(-0.5, 1, 0.5))} to get
+\code{cbind(c(1,0,0), c(-1, 0, 1), c(-0.5, 1, 0.5))} to get
 mean, additive effect, and dominance effect. The default is the
 identity matrix.}
 

--- a/man/scan1coef.Rd
+++ b/man/scan1coef.Rd
@@ -38,7 +38,7 @@ for individual identifiers. Ignored if \code{kinship} is provided.}
 
 \item{contrasts}{An optional matrix of genotype contrasts, size
 genotypes x genotypes. For an intercross, you might use
-\code{cbind(c(1,1,1), c(-0.5, 0, 0.5), c(-0.5, 1, -0.5))} to get
+\code{cbind(c(1,1,1), c(-1, 0, 1), c(-0.5, 1, -0.5))} to get
 mean, additive effect, and dominance effect. The default is the
 identity matrix.}
 

--- a/vignettes/user_guide.Rmd
+++ b/vignettes/user_guide.Rmd
@@ -798,7 +798,7 @@ provide a square matrix of _contrasts_, as follows:
 
 ```{r est_effects_liver_c2_contr}
 c2effB <- scan1coef(pr[,"2"], iron$pheno[,"liver"],
-                    contrasts=cbind(mu=c(1,1,1), a=c(-0.5, 0, 0.5), d=c(-0.5, 1, -0.5)))
+                    contrasts=cbind(mu=c(1,1,1), a=c(-1, 0, 1), d=c(-0.5, 1, -0.5)))
 
 ```
 
@@ -839,7 +839,7 @@ matrix of contrasts.
 
 ```{r est_effects_pg_liver_c2_contr}
 c2effB_pg <- scan1coef(pr[,"2"], iron$pheno[,"liver"], kinship_loco[["2"]],
-                       contrasts=cbind(mu=c(1,1,1), a=c(-0.5, 0, 0.5), d=c(-0.5, 1, -0.5)))
+                       contrasts=cbind(mu=c(1,1,1), a=c(-1, 0, 1), d=c(-0.5, 1, -0.5)))
 ```
 
 Here's a plot of the results.


### PR DESCRIPTION
- contrast for additive effect in an intercross should be (-1,0,1) not (-1/2,0,1/2)
- Fixed examples in `scan1coef()`, `scan1blup()`, `fit1()`, and the user guide.