### PR TITLE
Remove preserve_intercept arg from scan1blup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.5-19
-Date: 2017-07-16
+Version: 0.5-20
+Date: 2017-08-08
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a
     reimplementation of the R/qtl package to better handle

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,15 @@
-## qtl2scan 0.5-18 (2016-07-09)
+## qtl2scan 0.5-20 (2017-08-08)
+
+### New features
+
+- Removed the `preserve_intercept` argument from `scan1blup()`. The
+  default (`FALSE`), adding the intercept to the BLUPs, no longer
+  makes sense to me. (Better to have an option in `scan1coef()` to get
+  estimated genetic effects that sum to 0; which we'll add in the
+  future.)
+
+
+## qtl2scan 0.5-18 (2017-07-09)
 
 ### Bug fixes
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -357,8 +357,8 @@ scan_pg_onechr_intcovar_lowmem <- function(genoprobs, pheno, addcovar, intcovar,
     .Call(`_qtl2scan_scan_pg_onechr_intcovar_lowmem`, genoprobs, pheno, addcovar, intcovar, eigenvec, weights, tol)
 }
 
-scanblup <- function(genoprobs, pheno, addcovar, se, reml, preserve_intercept, tol = 1e-12) {
-    .Call(`_qtl2scan_scanblup`, genoprobs, pheno, addcovar, se, reml, preserve_intercept, tol)
+scanblup <- function(genoprobs, pheno, addcovar, se, reml, tol = 1e-12) {
+    .Call(`_qtl2scan_scanblup`, genoprobs, pheno, addcovar, se, reml, tol)
 }
 
 scancoef_binary_addcovar <- function(genoprobs, pheno, addcovar, weights, maxit = 100L, tol = 1e-6, qr_tol = 1e-12) {

--- a/R/scan1blup_pg.R
+++ b/R/scan1blup_pg.R
@@ -1,7 +1,7 @@
 # Calculate BLUPs of QTL effects in scan along one chromosome, with residual polygenic effect
 scan1blup_pg <-
     function(genoprobs, pheno, kinship, addcovar=NULL, nullcovar=NULL,
-             contrasts=NULL, se=FALSE, reml=TRUE, preserve_intercept=FALSE,
+             contrasts=NULL, se=FALSE, reml=TRUE,
              tol=1e-12, cores=1, quiet=TRUE)
 {
     stopifnot(tol > 0)
@@ -122,11 +122,11 @@ scan1blup_pg <-
     batches <- batch_vec(seq_len(n_pos), ceiling(n_pos/n_cores(cores)))
 
     by_group_func <- function(i)
-        scanblup(genoprobs[,,batches[[i]],drop=FALSE], pheno, addcovar, se, reml, preserve_intercept, tol)
+        scanblup(genoprobs[,,batches[[i]],drop=FALSE], pheno, addcovar, se, reml, tol)
 
     # scan to get BLUPs and coefficient estimates
     if(n_cores(cores)==1) {
-        result <- scanblup(genoprobs, pheno, addcovar, se, reml, preserve_intercept, tol)
+        result <- scanblup(genoprobs, pheno, addcovar, se, reml, tol)
         if(se) SE <- t(result$SE)
         else SE <- NULL
         coef <- t(result$coef)
@@ -147,10 +147,7 @@ scan1blup_pg <-
     }
 
     # add names
-    if(preserve_intercept)
-        coefnames <- scan1coef_names(genoprobs, addcovar, NULL)
-    else
-        coefnames <- scan1coef_names(genoprobs, addcovar[,-1,drop=FALSE], NULL)
+    coefnames <- scan1coef_names(genoprobs, addcovar, NULL)
     dimnames(coef) <- list(dimnames(genoprobs)[[3]], coefnames)
     if(se) dimnames(SE) <- dimnames(coef)
 

--- a/man/scan1blup.Rd
+++ b/man/scan1blup.Rd
@@ -6,8 +6,7 @@
 \usage{
 scan1blup(genoprobs, pheno, kinship = NULL, addcovar = NULL,
   nullcovar = NULL, contrasts = NULL, se = FALSE, reml = TRUE,
-  preserve_intercept = FALSE, tol = 0.000000000001, cores = 1,
-  quiet = TRUE)
+  tol = 0.000000000001, cores = 1, quiet = TRUE)
 }
 \arguments{
 \item{genoprobs}{Genotype probabilities as calculated by
@@ -40,12 +39,6 @@ identity matrix.}
 
 \item{reml}{If \code{reml=TRUE}, use
 REML to estimate variance components; otherwise maximum likelihood.}
-
-\item{preserve_intercept}{If TRUE, the BLUPs will have mean zero
-and there will be a separate column for the intercept. If FALSE
-(the default), we'll add the intercept to the BLUPs to give results
-that are comparable to \code{\link{scan1coef}}.
-Taken as TRUE if \code{contrasts} provided.}
 
 \item{tol}{Tolerance value for convergence of linear mixed model fit.}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1284,8 +1284,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // scanblup
-List scanblup(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const bool se, const bool reml, const bool preserve_intercept, const double tol);
-RcppExport SEXP _qtl2scan_scanblup(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP seSEXP, SEXP remlSEXP, SEXP preserve_interceptSEXP, SEXP tolSEXP) {
+List scanblup(const NumericVector& genoprobs, const NumericVector& pheno, const NumericMatrix& addcovar, const bool se, const bool reml, const double tol);
+RcppExport SEXP _qtl2scan_scanblup(SEXP genoprobsSEXP, SEXP phenoSEXP, SEXP addcovarSEXP, SEXP seSEXP, SEXP remlSEXP, SEXP tolSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1294,9 +1294,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< const NumericMatrix& >::type addcovar(addcovarSEXP);
     Rcpp::traits::input_parameter< const bool >::type se(seSEXP);
     Rcpp::traits::input_parameter< const bool >::type reml(remlSEXP);
-    Rcpp::traits::input_parameter< const bool >::type preserve_intercept(preserve_interceptSEXP);
     Rcpp::traits::input_parameter< const double >::type tol(tolSEXP);
-    rcpp_result_gen = Rcpp::wrap(scanblup(genoprobs, pheno, addcovar, se, reml, preserve_intercept, tol));
+    rcpp_result_gen = Rcpp::wrap(scanblup(genoprobs, pheno, addcovar, se, reml, tol));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1678,7 +1677,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_qtl2scan_scan_pg_onechr", (DL_FUNC) &_qtl2scan_scan_pg_onechr, 6},
     {"_qtl2scan_scan_pg_onechr_intcovar_highmem", (DL_FUNC) &_qtl2scan_scan_pg_onechr_intcovar_highmem, 7},
     {"_qtl2scan_scan_pg_onechr_intcovar_lowmem", (DL_FUNC) &_qtl2scan_scan_pg_onechr_intcovar_lowmem, 7},
-    {"_qtl2scan_scanblup", (DL_FUNC) &_qtl2scan_scanblup, 7},
+    {"_qtl2scan_scanblup", (DL_FUNC) &_qtl2scan_scanblup, 6},
     {"_qtl2scan_scancoef_binary_addcovar", (DL_FUNC) &_qtl2scan_scancoef_binary_addcovar, 7},
     {"_qtl2scan_scancoef_binary_intcovar", (DL_FUNC) &_qtl2scan_scancoef_binary_intcovar, 8},
     {"_qtl2scan_scancoefSE_binary_addcovar", (DL_FUNC) &_qtl2scan_scancoefSE_binary_addcovar, 7},

--- a/src/scan1blup.h
+++ b/src/scan1blup.h
@@ -13,7 +13,6 @@
 // se        = If TRUE, calculate SEs
 // reml      = If TRUE, use REML to estimate variance components; otherwise use maximum
 //             likelihood
-// preserve_intercept = If FALSE, add the intercept to the BLUPs and remove that column
 // tol       = Numeric tolerance
 //
 // output    = List with two matrices, of coefficients and SEs (each coefficients x positions)
@@ -22,7 +21,6 @@ Rcpp::List scanblup(const Rcpp::NumericVector& genoprobs,
                     const Rcpp::NumericMatrix& addcovar,
                     const bool se,
                     const bool reml,
-                    const bool preserve_intercept,
                     const double tol);
 
 #endif // SCAN1BLUP_H

--- a/tests/testthat/test-scan1blup.R
+++ b/tests/testthat/test-scan1blup.R
@@ -54,15 +54,11 @@ test_that("scan1blup works with no kinship matrix", {
     blup_se <- scan1blup(pr, phe, se=TRUE)
     expect_equivalent(blup, blup_se)
 
-    # cf preserve intercept vs not
-    blup_int <- scan1blup(pr, phe, preserve_intercept=TRUE)
-    expect_equivalent(unclass(blup), unclass(blup_int)[,1:3] + unclass(blup_int)[,4])
-
     # brute force BLUPs
     for(i in 1:dim(pr[[1]])[[3]]) {
         blup_alt <- calc_blup(pr[[1]][,,i], phe)
-        names(blup_alt) <- colnames(blup_int)
-        expect_equal(unclass(blup_int)[i,], blup_alt, tol=1e-6)
+        names(blup_alt) <- colnames(blup)
+        expect_equal(unclass(blup)[i,], blup_alt, tol=1e-6)
     }
 
     # repeat with an additive covariate
@@ -73,15 +69,11 @@ test_that("scan1blup works with no kinship matrix", {
     blup_se <- scan1blup(pr, phe, addcovar=sex, se=TRUE)
     expect_equivalent(blup, blup_se)
 
-    # cf preserve intercept vs not
-    blup_int <- scan1blup(pr, phe, addcovar=sex, preserve_intercept=TRUE)
-    expect_equivalent(unclass(blup), unclass(blup_int)[,c(1:3,5)] + cbind(unclass(blup_int)[,c(4,4,4)], 0))
-
     # brute force BLUPs
     for(i in 1:dim(pr[[1]])[[3]]) {
         blup_alt <- calc_blup(pr[[1]][,,i], phe, addcovar=sex)
-        names(blup_alt) <- colnames(blup_int)
-        expect_equal(unclass(blup_int)[i,], blup_alt, tolerance=1e-5)
+        names(blup_alt) <- colnames(blup)
+        expect_equal(unclass(blup)[i,], blup_alt, tolerance=1e-5)
     }
 
 })
@@ -100,15 +92,11 @@ test_that("scan1blup works with kinship matrix", {
     blup_se <- scan1blup(pr, phe, K, sex, se=TRUE)
     expect_equivalent(blup, blup_se)
 
-    # cf preserve intercept vs not
-    blup_int <- scan1blup(pr, phe, K, sex, preserve_intercept=TRUE)
-    expect_equivalent(unclass(blup), unclass(blup_int)[,c(1:3,5)] + cbind(unclass(blup_int)[,c(4,4,4)], 0))
-
     # brute force BLUPs
     for(i in 1:dim(pr[[1]])[[3]]) {
         blup_alt <- calc_blup(pr[[1]][,,i], phe, K, sex)
-        names(blup_alt) <- colnames(blup_int)
-        expect_equal(unclass(blup_int)[i,], blup_alt, tolerance=1e-5)
+        names(blup_alt) <- colnames(blup)
+        expect_equal(unclass(blup)[i,], blup_alt, tolerance=1e-5)
     }
 
 })
@@ -127,15 +115,11 @@ test_that("scan1blup works with kinship matrix on another chromosome", {
     blup_se <- scan1blup(pr, phe, K, sex, se=TRUE)
     expect_equivalent(blup, blup_se)
 
-    # cf preserve intercept vs not
-    blup_int <- scan1blup(pr, phe, K, sex, preserve_intercept=TRUE)
-    expect_equivalent(unclass(blup), unclass(blup_int)[,c(1:3,5)] + cbind(unclass(blup_int)[,c(4,4,4)], 0))
-
     # brute force BLUPs
     for(i in 1:dim(pr[[1]])[[3]]) {
         blup_alt <- calc_blup(pr[[1]][,,i], phe, K, sex)
-        names(blup_alt) <- colnames(blup_int)
-        expect_equal(unclass(blup_int)[i,], blup_alt, tolerance=1e-5)
+        names(blup_alt) <- colnames(blup)
+        expect_equal(unclass(blup)[i,], blup_alt, tolerance=1e-5)
     }
 
 })


### PR DESCRIPTION
 - No longer makes sense to me to add intercept to the BLUPs; now
   preserving the intercept with no option not to.

 - Better, I think is to have an option in scan1coef to get genetic
   effect estimates that sum to 0. But could just leave that to the
   user.

- Fixes Issue #98 