### PR TITLE
Dependent cols; +/- Inf; check sizes in linreg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
 Version: 0.5-20
-Date: 2017-08-08
+Date: 2017-08-09
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a
     reimplementation of the R/qtl package to better handle

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## qtl2scan 0.5-20 (2017-08-08)
+## qtl2scan 0.5-20 (2017-08-09)
 
 ### New features
 
@@ -7,6 +7,17 @@
   makes sense to me. (Better to have an option in `scan1coef()` to get
   estimated genetic effects that sum to 0; which we'll add in the
   future.)
+
+### Minor changes
+
+- Check for linearly dependent columns in covariate matrices _after_
+  omitting individuals.
+
+- Check for +/- Inf in the phenotypes and covariates, rather than just
+  NAs.
+
+- In linear regression routines, and checks that inputs are
+  appropriately sized.
 
 
 ## qtl2scan 0.5-18 (2017-07-09)

--- a/R/batch_cols.R
+++ b/R/batch_cols.R
@@ -25,7 +25,7 @@ batch_cols <-
     if(is.null(max_batch) || max_batch<=0)
         max_batch <- ncol(mat)
 
-    mat <- is.na(mat)
+    mat <- !is.finite(mat)
     n <- nrow(mat)
     all_true <- rep(TRUE, n)
     result <- NULL

--- a/R/est_herit.R
+++ b/R/est_herit.R
@@ -90,7 +90,7 @@ est_herit <-
     # find individuals in common across all arguments
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(kinshipIDs, addcovar, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(!is.na(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/get_common_ids.R
+++ b/R/get_common_ids.R
@@ -46,18 +46,27 @@ get_common_ids <-
                 stop("Can't handle arrays with >3 dimensions")
             these <- rownames(args[[i]])
             if(complete.cases && (is.matrix(args[[i]]) || is.data.frame(args[[i]])))
-                these <- these[complete.cases(args[[i]])]
+                these <- these[rowSums(!is.finite(args[[i]]))==0]
         }
         else if(is.list(args[[i]]) && !is.null(rownames(args[[i]][[1]]))) {
             these <- rownames(args[[i]][[1]])
         }
         else if(is.vector(args[[i]])) {
-            if(is.character(args[[i]]) && is.null(names(args[[i]])))
-                these <- args[[i]]
+            if(is.character(args[[i]])) {
+                if(is.null(names(args[[i]]))) {
+                    these <- args[[i]]
+                } else {
+                    these <- names(args[[i]])
+                    if(complete.cases) {
+                        these <- these[!is.na(args[[i]])]
+                    }
+                }
+            }
             else {
                 these <- names(args[[i]])
-                if(complete.cases)
-                    these <- these[!is.na(args[[i]])]
+                if(complete.cases) {
+                    these <- these[is.finite(args[[i]])]
+                }
             }
         }
         else {

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -180,7 +180,7 @@ scan1 <-
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, addcovar, Xcovar, intcovar,
                                weights, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(!is.na(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/scan1.R
+++ b/R/scan1.R
@@ -240,9 +240,9 @@ scan1 <-
             pr <- genoprobs[[chr]][these2keep,-1,,drop=FALSE]
 
         # subset the rest
-        ac <- addcovar; if(!is.null(ac)) ac <- ac[these2keep,,drop=FALSE]
+        ac <- addcovar; if(!is.null(ac)) { ac <- ac[these2keep,,drop=FALSE]; ac <- drop_depcols(ac, TRUE, tol) }
         Xc <- Xcovar;   if(!is.null(Xc)) Xc <- Xc[these2keep,,drop=FALSE]
-        ic <- intcovar; if(!is.null(ic)) ic <- ic[these2keep,,drop=FALSE]
+        ic <- intcovar; if(!is.null(ic)) { ic <- ic[these2keep,,drop=FALSE]; ic <- drop_depcols(ic, TRUE, tol) }
         ph <- pheno[these2keep,phecol,drop=FALSE]
         wts <- weights[these2keep]
 

--- a/R/scan1_pg.R
+++ b/R/scan1_pg.R
@@ -111,9 +111,9 @@ scan1_pg <-
 
         # subset the rest
         K <- subset_kinship(kinship, ind=these2keep)
-        ac <- addcovar; if(!is.null(ac)) ac <- ac[these2keep,,drop=FALSE]
+        ac <- addcovar; if(!is.null(ac)) { ac <- ac[these2keep,,drop=FALSE]; ac <- drop_depcols(ac, TRUE, tol) }
         Xc <- Xcovar;   if(!is.null(Xc)) Xc <- Xc[these2keep,,drop=FALSE]
-        ic <- intcovar; if(!is.null(ic)) ic <- ic[these2keep,,drop=FALSE]
+        ic <- intcovar; if(!is.null(ic)) { ic <- ic[these2keep,,drop=FALSE]; ic <- drop_depcols(ic, TRUE, tol) }
         ph <- pheno[these2keep,phecol,drop=FALSE]
 
         # eigen decomposition of kinship matrix

--- a/R/scan1_pg.R
+++ b/R/scan1_pg.R
@@ -43,7 +43,7 @@ scan1_pg <-
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, addcovar, Xcovar, intcovar,
                                kinshipIDs, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(!is.na(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")

--- a/R/scan1perm.R
+++ b/R/scan1perm.R
@@ -220,7 +220,7 @@ scan1perm <-
     # and drop individuals with missing covariates or missing *all* phenotypes
     ind2keep <- get_common_ids(genoprobs, addcovar, Xcovar, intcovar,
                                kinshipIDs, weights, perm_strata, complete.cases=TRUE)
-    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(!is.na(pheno)) > 0])
+    ind2keep <- get_common_ids(ind2keep, rownames(pheno)[rowSums(is.finite(pheno)) > 0])
     if(length(ind2keep)<=2) {
         if(length(ind2keep)==0)
             stop("No individuals in common.")
@@ -247,7 +247,7 @@ scan1perm <-
 
     if(model=="normal" && is.null(addcovar) && is.null(Xcovar) &&
        is.null(intcovar) && is.null(weights)
-       && sum(is.na(pheno[ind2keep,]))==0) # no covariates, no weights, no missing phenotypes
+       && sum(!is.finite(pheno[ind2keep,]))==0) # no covariates, no weights, no missing phenotypes
         result <- scan1perm_nocovar(genoprobs=genoprobs,
                                     pheno=pheno,
                                     n_perm=n_perm,

--- a/src/binreg_eigen.cpp
+++ b/src/binreg_eigen.cpp
@@ -19,8 +19,10 @@ double calc_ll_binreg_eigenchol(const NumericMatrix& X, const NumericVector& y,
                                 const int maxit=100, const double tol=1e-6)
 {
     const int n_ind = y.size();
+    #ifndef NDEBUG
     if(n_ind != X.rows())
         throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
 
     double curllik = 0.0;
     NumericVector pi(n_ind), wt(n_ind), nu(n_ind), z(n_ind);
@@ -77,8 +79,10 @@ double calc_ll_binreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
                               const double qr_tol=1e-12)
 {
     const int n_ind = y.size();
+    #ifndef NDEBUG
     if(n_ind != X.rows())
         throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
 
     double curllik = 0.0;
     NumericVector pi(n_ind), wt(n_ind), nu(n_ind), z(n_ind);
@@ -171,8 +175,10 @@ List fit_binreg_eigenqr(const NumericMatrix& X,
                               const double qr_tol=1e-12)
 {
     const int n_ind = y.size();
+    #ifndef NDEBUG
     if(n_ind != X.rows())
         throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
 
     double curllik = 0.0;
     NumericVector pi(n_ind), wt(n_ind), nu(n_ind), z(n_ind);

--- a/src/linreg_eigen.cpp
+++ b/src/linreg_eigen.cpp
@@ -25,6 +25,11 @@ List fit_linreg_eigenchol(const NumericMatrix& X, const NumericVector& y, const 
     const VectorXd yy(as<Map<VectorXd> >(y));
 
     const int n = XX.rows(), p=XX.cols();
+    #ifndef NDEBUG
+    if(n != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     LLT<MatrixXd> llt ( calc_XpX(XX) );
 
     VectorXd betahat = llt.solve(XX.adjoint() * yy);
@@ -60,6 +65,11 @@ List fit_linreg_eigenchol(const NumericMatrix& X, const NumericVector& y, const 
 // [[Rcpp::export]]
 NumericVector calc_coef_linreg_eigenchol(const NumericMatrix& X, const NumericVector& y)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -75,6 +85,11 @@ NumericVector calc_coef_linreg_eigenchol(const NumericMatrix& X, const NumericVe
 // [[Rcpp::export]]
 List calc_coefSE_linreg_eigenchol(const NumericMatrix& X, const NumericVector& y)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -97,6 +112,11 @@ List calc_coefSE_linreg_eigenchol(const NumericMatrix& X, const NumericVector& y
 // [[Rcpp::export]]
 double calc_rss_eigenchol(const NumericMatrix& X, const NumericVector& y)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -113,6 +133,11 @@ double calc_rss_eigenchol(const NumericMatrix& X, const NumericVector& y)
 // [[Rcpp::export]]
 NumericVector calc_fitted_linreg_eigenchol(const NumericMatrix& X, const NumericVector& y)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -128,6 +153,11 @@ NumericVector calc_fitted_linreg_eigenchol(const NumericMatrix& X, const Numeric
 List fit_linreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
                         const bool se, const double tol=1e-12)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -204,6 +234,11 @@ List fit_linreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
 NumericVector calc_coef_linreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
                                        const double tol=1e-12)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -242,6 +277,11 @@ NumericVector calc_coef_linreg_eigenqr(const NumericMatrix& X, const NumericVect
 List calc_coefSE_linreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
                                 const double tol=1e-12)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -299,6 +339,11 @@ List calc_coefSE_linreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
 double calc_rss_eigenqr(const NumericMatrix& X, const NumericVector& y,
                         const double tol=1e-12)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -335,6 +380,11 @@ double calc_rss_eigenqr(const NumericMatrix& X, const NumericVector& y,
 NumericVector calc_fitted_linreg_eigenqr(const NumericMatrix& X, const NumericVector& y,
                                          const double tol=1e-12)
 {
+    #ifndef NDEBUG
+    if(X.rows() != y.size())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const VectorXd yy(as<Map<VectorXd> >(y));
 
@@ -369,6 +419,11 @@ NumericVector calc_fitted_linreg_eigenqr(const NumericMatrix& X, const NumericVe
 // [[Rcpp::export]]
 NumericVector calc_mvrss_eigenchol(const NumericMatrix& X, const NumericMatrix& Y)
 {
+    #ifndef NDEBUG
+    if(X.rows() != Y.rows())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const int ncolY = Y.cols();
     const int ncolX = X.cols();
 
@@ -396,6 +451,11 @@ NumericVector calc_mvrss_eigenchol(const NumericMatrix& X, const NumericMatrix& 
 NumericVector calc_mvrss_eigenqr(const NumericMatrix& X, const NumericMatrix& Y,
                                  const double tol=1e-12)
 {
+    #ifndef NDEBUG
+    if(X.rows() != Y.rows())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const MatrixXd YY(as<Map<MatrixXd> >(Y));
 
@@ -444,6 +504,11 @@ NumericVector calc_mvrss_eigenqr(const NumericMatrix& X, const NumericMatrix& Y,
 // [[Rcpp::export]]
 NumericMatrix calc_resid_eigenchol(const NumericMatrix& X, const NumericMatrix& Y)
 {
+    #ifndef NDEBUG
+    if(X.rows() != Y.rows())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const int ncolY = Y.cols();
     const int ncolX = X.cols();
 
@@ -472,6 +537,11 @@ NumericMatrix calc_resid_eigenchol(const NumericMatrix& X, const NumericMatrix& 
 NumericMatrix calc_resid_eigenqr(const NumericMatrix& X, const NumericMatrix& Y,
                                  const double tol=1e-12)
 {
+    #ifndef NDEBUG
+    if(X.rows() != Y.rows())
+        throw std::invalid_argument("nrow(X) != length(y)");
+    #endif
+
     const MatrixXd XX(as<Map<MatrixXd> >(X));
     const MatrixXd YY(as<Map<MatrixXd> >(Y));
 

--- a/tests/testthat/test-reduced_rank_covar_scan.R
+++ b/tests/testthat/test-reduced_rank_covar_scan.R
@@ -1,0 +1,78 @@
+context("reduced rank covariates")
+
+test_that("scan1 etc work with reduced-rank covariates", {
+
+    library(qtl2geno)
+    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
+    iron <- iron[,c(1,12,"X")]
+
+    Xcovar <- get_x_covar(iron)
+    set.seed(3706216)
+    n_batch <- 4
+    batch <- sample(1:n_batch, n_ind(iron), replace=TRUE)
+    X <- matrix(0, nrow=n_ind(iron), ncol=n_batch-1)
+    dimnames(X) <- list(rownames(Xcovar), paste0("batch", 2:n_batch))
+    for(i in 2:n_batch) X[batch==i,i-1] <- 1
+
+    pr <- calc_genoprob(iron, error_prob=0.01)
+
+    phe <- iron$pheno
+    phe[batch==n_batch,1] <- NA
+    phe[batch==1,2] <- NA
+
+    k <- calc_kinship(pr)
+
+    # scan1 with no kinship
+    out <- scan1(pr, phe, Xcovar=Xcovar, addcovar=X)
+    expected <- cbind(scan1(pr, phe[!is.na(phe[,1]),1,drop=FALSE], Xcovar=Xcovar, addcovar=X[,-3]),
+                      scan1(pr, phe[!is.na(phe[,2]),2,drop=FALSE], Xcovar=Xcovar, addcovar=X[,-3]))
+    expect_equal(out, expected)
+
+    # scan1 with kinship
+    out_k <- scan1(pr, phe, k, Xcovar=Xcovar, addcovar=X)
+    expected_k <- cbind(scan1(pr, phe[!is.na(phe[,1]),1,drop=FALSE], k, Xcovar=Xcovar, addcovar=X[,-3]),
+                        scan1(pr, phe[!is.na(phe[,2]),2,drop=FALSE], k, Xcovar=Xcovar, addcovar=X[,-3]))
+    expect_equal(out_k, expected_k, tol=1e-6)
+
+    # scan1coef with no kinship
+    for(phecol in 1:2) {
+        for(chr in names(pr)) {
+            co <- scan1coef(pr[,chr], phe[,phecol,drop=FALSE], addcovar=X)
+            # not clear which column to drop in 2nd case
+            expected <- scan1coef(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], addcovar=X[,-c(3,2)[phecol]])
+            expect_equal(co, expected)
+        }
+    }
+
+    # scan1coef with kinship
+    for(phecol in 1:2) {
+        for(chr in names(pr)) {
+            co <- scan1coef(pr[,chr], phe[,phecol,drop=FALSE], k, addcovar=X)
+            # not clear which column to drop in 2nd case
+            expected <- scan1coef(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], k, addcovar=X[,-c(3,2)[phecol]])
+            expect_equal(co, expected)
+        }
+    }
+
+
+    # scan1blup with no kinship
+    for(phecol in 1:2) {
+        for(chr in names(pr)) {
+            co <- scan1blup(pr[,chr], phe[,phecol,drop=FALSE], addcovar=X)
+            # not clear which column to drop in 2nd case
+            expected <- scan1blup(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], addcovar=X[,-c(3,2)[phecol]])
+            expect_equal(co, expected)
+        }
+    }
+
+    # scan1blup with kinship
+    for(phecol in 1:2) {
+        for(chr in names(pr)) {
+            co <- scan1blup(pr[,chr], phe[,phecol,drop=FALSE], k, addcovar=X)
+            # not clear which column to drop in 2nd case
+            expected <- scan1blup(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], k, addcovar=X[,-c(3,2)[phecol]])
+            expect_equal(co, expected)
+        }
+    }
+
+})

--- a/tests/testthat/test-reduced_rank_covar_scan.R
+++ b/tests/testthat/test-reduced_rank_covar_scan.R
@@ -32,7 +32,7 @@ test_that("scan1 etc work with reduced-rank covariates", {
     out_k <- scan1(pr, phe, k, Xcovar=Xcovar, addcovar=X)
     expected_k <- cbind(scan1(pr, phe[!is.na(phe[,1]),1,drop=FALSE], k, Xcovar=Xcovar, addcovar=X[,-3]),
                         scan1(pr, phe[!is.na(phe[,2]),2,drop=FALSE], k, Xcovar=Xcovar, addcovar=X[,-3]))
-    expect_equal(out_k, expected_k, tol=1e-6)
+    expect_equal(out_k, expected_k, tol=5e-6)
 
     # scan1coef with no kinship
     for(phecol in 1:2) {


### PR DESCRIPTION
- Check for linearly dependent columns in covariate matrices _after_ omitting individuals. (Issue #76)

- Check for +/- Inf in the phenotypes and covariates, rather than just NAs. (Issue #75)

- In linear regression routines, and checks that inputs are appropriately sized. (Issue #4)