### PR TITLE
Fix bug in est_herit() re linearly dependent covariates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.5-22
-Date: 2017-09-15
+Version: 0.5-23
+Date: 2017-10-17
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a
     reimplementation of the R/qtl package to better handle

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,14 @@
-## qtl2scan 0.5-21 (2017-08-11)
+## qtl2scan 0.5-23 (2017-10-17)
 
 ### Minor changes
 
 - Turn off debug C++ code
+
+### Bug fixes
+
+- Fix bug in `est_herit()` regarding dependent covariate columns when
+  missing values in the phenotypes. Need to call `drop_depcols()`
+  again after having omitted individuals with missing phenotypes.
 
 
 ## qtl2scan 0.5-20 (2017-08-09)

--- a/R/est_herit.R
+++ b/R/est_herit.R
@@ -132,7 +132,7 @@ est_herit <-
 
         # subset the rest
         K <- kinship[these2keep, these2keep]
-        ac <- addcovar; if(!is.null(ac)) ac <- ac[these2keep,,drop=FALSE]
+        ac <- addcovar; if(!is.null(ac)) { ac <- ac[these2keep,,drop=FALSE]; ac <- drop_depcols(ac, TRUE, tol) }
         ph <- pheno[these2keep,phecol,drop=FALSE]
 
         # eigen decomposition of kinship matrix

--- a/tests/testthat/test-est_herit.R
+++ b/tests/testthat/test-est_herit.R
@@ -57,3 +57,35 @@ test_that("est_herit with intercross with an additive covariate", {
     expect_equal(est_herit(iron$pheno, kinship[subind,subind], addcovar=X[subind]), expected)
 
 })
+
+test_that("est_herit handles dependent covariate columns", {
+
+    library(qtl2geno)
+    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2geno"))
+    map <- insert_pseudomarkers(iron$gmap, step=1)
+    probs <- calc_genoprob(iron, map, error_prob=0.002)
+    kinship <- calc_kinship(probs)
+    pheno <- iron$pheno
+    covar <- match(iron$covar$sex, c("f", "m")) # make numeric
+    names(covar) <- rownames(iron$covar)
+
+    covar2 <- cbind(a=covar,b=0)
+    pheno[1:2,1] <- NA
+    covar2[1:2,2] <- 1
+    hsq <- est_herit(pheno, kinship, covar)
+    hsq2 <- est_herit(pheno, kinship, covar2)
+    hsq3 <- est_herit(pheno, kinship, covar2[,-2, drop=FALSE])
+
+    expect_equal(hsq[1], hsq2[1])
+    expect_equal(hsq2[2], structure(0.545220193658054, .Names = "spleen"))
+    expect_equal(hsq, hsq3)
+
+    pheno[1:2,1:2] <- NA
+    hsq <- est_herit(pheno, kinship, covar)
+    hsq2 <- est_herit(pheno, kinship, covar2)
+    hsq3 <- est_herit(pheno, kinship, covar2[,-2, drop=FALSE])
+
+    expect_equal(hsq, hsq2)
+    expect_equal(hsq, hsq3)
+
+})

--- a/tests/testthat/test-est_herit.R
+++ b/tests/testthat/test-est_herit.R
@@ -77,7 +77,7 @@ test_that("est_herit handles dependent covariate columns", {
     hsq3 <- est_herit(pheno, kinship, covar2[,-2, drop=FALSE])
 
     expect_equal(hsq[1], hsq2[1])
-    expect_equal(hsq2[2], structure(0.545220193658054, .Names = "spleen"))
+    expect_equal(hsq2[2], structure(0.545220193658054, .Names = "spleen"), tolerance=1e-7)
     expect_equal(hsq, hsq3)
 
     pheno[1:2,1:2] <- NA


### PR DESCRIPTION
Fixes Issue #112. As in PR #108 (which fixed a similar problem in `scan1()`), need to call `drop_depcols()` again after having omitted individuals with missing phenotypes.