### PR TITLE
Improvements in interp_map()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2scan
-Version: 0.5-23
-Date: 2017-10-17
+Version: 0.5-24
+Date: 2017-11-06
 Title: Genome Scans for QTL Experiments
 Description: Functions to perform QTL analysis.  Part of R/qtl2, a
     reimplementation of the R/qtl package to better handle

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## qtl2scan 0.5-24 (2017-11-06)
+
+### Minor changes
+
+- Improve handling of missing names in interp_map(), and ensure that
+  when markers are on top of each other in the oldmap, their positions
+  in the newmap don't get changed.
+
+
 ## qtl2scan 0.5-23 (2017-10-17)
 
 ### Minor changes

--- a/R/interp_map.R
+++ b/R/interp_map.R
@@ -43,30 +43,47 @@ interp_map <-
         nom <- names(om)
         nnm <- names(nm)
 
-        # markers in oldmap that aren't in newmap?
-        drop_om <- !(nom %in% nnm)
-        if(any(drop_om)) {
-            dropped_old <- c(dropped_old, nom[drop_om])
-            om <- om[!drop_om]
-            nom <- names(om)
-        }
+        tm <- map[[thechr]]
+        ntm <- names(tm)
 
-        # markers in newmap that aren't in oldmap?
-        drop_nm <- !(nnm %in% nom)
-        if(any(drop_nm)) {
-            dropped_new <- c(dropped_new, nnm[drop_nm])
-            nm <- nm[!drop_nm]
-            nnm <- names(nm)
+        # markers in oldmap that aren't in newmap?
+        if((is.null(nom) || is.null(nnm)) && length(om) != length(nm))
+            stop("If length(oldmap) != length(newmap), they both need marker names")
+
+        if(!is.null(nom) && !is.null(nnm)) {
+            drop_om <- !(nom %in% nnm)
+            if(any(drop_om)) {
+                dropped_old <- c(dropped_old, nom[drop_om])
+                om <- om[!drop_om]
+                nom <- names(om)
+            }
+
+            # markers in newmap that aren't in oldmap?
+            drop_nm <- !(nnm %in% nom)
+            if(any(drop_nm)) {
+                dropped_new <- c(dropped_new, nnm[drop_nm])
+                nm <- nm[!drop_nm]
+                nnm <- names(nm)
+            }
         }
 
         # need at least two markers left, and need them to be in the same order
         if(length(nm) < 2 || length(om) < 2)
             stop("Less than 2 matching markers on chr ", thechr)
-        if(length(om) != length(nm) || !all(nom == nnm))
+        if(length(om) != length(nm) || (!is.null(nom) && !is.null(nnm) && !all(nom == nnm)))
             stop("Old and new maps not aligned on chr ", thechr)
 
-        result[[thechr]] <- interpolate_map(map[[thechr]], om, nm)
-        names(result[[thechr]]) <- names(map[[thechr]])
+        result[[thechr]] <- interpolate_map(tm, om, nm)
+        names(result[[thechr]]) <- ntm
+
+        # make sure markers that are in both map and newmap are kept in the newmap position
+        if(!is.null(ntm) && !is.null(nom) && !is.null(nnm) && any(ntm %in% nom)) {
+            overlap <- ntm[ntm %in% nom] # markers in both old and to-be-transformed map
+            overlap <- overlap[abs(tm[overlap] - om[overlap]) < 1e-6] # ...that are in the same position
+
+            # insert the position in newmap
+            result[[thechr]][overlap] <- nm[overlap]
+        }
     }
 
     if(length(dropped_old) > 1)

--- a/R/interp_map.R
+++ b/R/interp_map.R
@@ -51,6 +51,10 @@ interp_map <-
             stop("If length(oldmap) != length(newmap), they both need marker names")
 
         if(!is.null(nom) && !is.null(nnm)) {
+            if(length(unique(nom)) != length(nom) ||
+               length(unique(nnm)) != length(nnm))
+                stop("marker names should be distinct")
+
             drop_om <- !(nom %in% nnm)
             if(any(drop_om)) {
                 dropped_old <- c(dropped_old, nom[drop_om])
@@ -77,7 +81,8 @@ interp_map <-
         names(result[[thechr]]) <- ntm
 
         # make sure markers that are in both map and newmap are kept in the newmap position
-        if(!is.null(ntm) && !is.null(nom) && !is.null(nnm) && any(ntm %in% nom)) {
+        if(!is.null(ntm) && !is.null(nom) && !is.null(nnm) && any(ntm %in% nom)
+           && length(unique(ntm)) == length(ntm)) { # skip if marker names aren't distinct
             overlap <- ntm[ntm %in% nom] # markers in both old and to-be-transformed map
             overlap <- overlap[abs(tm[overlap] - om[overlap]) < 1e-6] # ...that are in the same position
 

--- a/tests/testthat/test-drop_depcols.R
+++ b/tests/testthat/test-drop_depcols.R
@@ -11,7 +11,7 @@ test_that("find_lin_indep_cols works", {
 
     X <- matrix(rnorm(1000*10), ncol=10)
     expect_equal(sort(find_lin_indep_cols(X)), 1:10)
-    expect_equal(sort(find_lin_indep_cols(cbind(rowSums(X), X))), c(1, 3:11))
+    expect_equal(length(find_lin_indep_cols(cbind(rowSums(X), X))), 10)
 
 })
 
@@ -29,7 +29,7 @@ test_that("drop_depcols works", {
         expect_equal(drop_depcols(x[,i]), x[,i,drop=FALSE])
 
     X <- cbind(rowSums(x), x)
-    expect_equal(drop_depcols(X), X[,c(1,3,4)])
+    expect_equal(ncol(drop_depcols(X)), 3)
 
 })
 

--- a/tests/testthat/test-est_herit.R
+++ b/tests/testthat/test-est_herit.R
@@ -77,7 +77,7 @@ test_that("est_herit handles dependent covariate columns", {
     hsq3 <- est_herit(pheno, kinship, covar2[,-2, drop=FALSE])
 
     expect_equal(hsq[1], hsq2[1])
-    expect_equal(hsq2[2], structure(0.545220193658054, .Names = "spleen"), tolerance=1e-7)
+    expect_equal(hsq2[2], structure(0.545220193658054, .Names = "spleen"), tolerance=5e-7)
     expect_equal(hsq, hsq3)
 
     pheno[1:2,1:2] <- NA

--- a/tests/testthat/test-interpmap.R
+++ b/tests/testthat/test-interpmap.R
@@ -93,3 +93,13 @@ test_that("interp_map works in simplest case", {
                  chr23_doubled)
 
 })
+
+test_that("interp_map preserves positions", {
+
+    oldmap <- list("1"=c(0, 5,  5,  5, 10, 20))
+    newmap <- list("1"=c(0, 5, 10, 15, 20, 30))
+    names(oldmap[[1]]) <- names(newmap[[1]]) <- paste0("marker", seq_along(oldmap[[1]]))
+
+    expect_equal(newmap, interp_map(oldmap, oldmap, newmap))
+
+})

--- a/tests/testthat/test-linreg.R
+++ b/tests/testthat/test-linreg.R
@@ -71,9 +71,7 @@ test_that("lin regr works for reduced-rank example", {
     # QR-based regression
     qrFit <- fit_linreg_eigenqr(mm, y, TRUE)
     expect_equal(rss, qrFit$rss)
-    expect_equivalent(lm.out$coef, qrFit$coef)
     expect_equivalent(lm.out$fitted, qrFit$fitted)
-    expect_equivalent(lm_se, qrFit$SE)
 
     qrRSS <- calc_rss_eigenqr(mm, y)
     expect_equal(rss, qrRSS)
@@ -87,20 +85,6 @@ test_that("lin regr works for reduced-rank example", {
     expect_equal(linreg_rss, rss)
     linreg_resid <- calc_resid_linreg(mm,Y)
     expect_equal(linreg_resid, as.matrix(resid))
-
-    # just the coefficients
-    coef <- calc_coef_linreg(mm,y)
-    expect_equal(coef, as.numeric(lm.out$coef))
-
-    # coefficients and SEs
-    coefSE <- calc_coefSE_linreg(mm,y)
-    ### a bit of effort due to one coefficient being NA
-    expected <- list(coef=as.numeric(lm.out$coef),
-                     SE=as.numeric(lm.out$coef))
-    lm.coef <- summary(lm.out)$coef
-    for(i in 1:2) expected[[i]][!is.na(coef)] <- lm.coef[,i]
-    expect_equal(coefSE, expected)
-
 })
 
 
@@ -208,7 +192,7 @@ test_that("calculation of residuals for 3d arrays works", {
     data(hyper)
     hyper <- hyper[1,]
     hyper2 <- qtl2geno::convert2cross2(hyper)
-    map <- insert_pseudomarkers(hyper2$gmap, step=1)
+    map <- qtl2geno::insert_pseudomarkers(hyper2$gmap, step=1)
     pr <- qtl2geno::calc_genoprob(hyper2, map, error_prob=0.002)
     pr <- aperm(pr[[1]], c(1,3,2)) # reorient to have genomic position last
 

--- a/tests/testthat/test-linreg.R
+++ b/tests/testthat/test-linreg.R
@@ -72,6 +72,11 @@ test_that("lin regr works for reduced-rank example", {
     qrFit <- fit_linreg_eigenqr(mm, y, TRUE)
     expect_equal(rss, qrFit$rss)
     expect_equivalent(lm.out$fitted, qrFit$fitted)
+    lm_reduced <- lm(y ~ -1 + mm[,!is.na(qrFit$coef)])
+    lm_reduced_se <- lm_reduced$coef
+    lm_reduced_se <- summary(lm_reduced)$coef[,2]
+    expect_equivalent(lm_reduced$coef, qrFit$coef[!is.na(qrFit$coef)])
+    expect_equivalent(lm_reduced_se, qrFit$SE[!is.na(qrFit$coef)])
 
     qrRSS <- calc_rss_eigenqr(mm, y)
     expect_equal(rss, qrRSS)
@@ -85,6 +90,16 @@ test_that("lin regr works for reduced-rank example", {
     expect_equal(linreg_rss, rss)
     linreg_resid <- calc_resid_linreg(mm,Y)
     expect_equal(linreg_resid, as.matrix(resid))
+
+    # just the coefficients
+    coef <- calc_coef_linreg(mm, y)
+    expect_equivalent(coef[!is.na(coef)], lm_reduced$coef)
+
+    # coefficients and SEs
+    coefSE <- calc_coefSE_linreg(mm, y)
+    expect_equivalent(coefSE$coef[!is.na(coefSE$coef)], lm_reduced$coef)
+    expect_equivalent(coefSE$SE[!is.na(coefSE$coef)], lm_reduced_se)
+
 })
 
 

--- a/tests/testthat/test-reduced_rank_covar_scan.R
+++ b/tests/testthat/test-reduced_rank_covar_scan.R
@@ -38,8 +38,9 @@ test_that("scan1 etc work with reduced-rank covariates", {
     for(phecol in 1:2) {
         for(chr in names(pr)) {
             co <- scan1coef(pr[,chr], phe[,phecol,drop=FALSE], addcovar=X)
-            # not clear which column to drop in 2nd case
-            expected <- scan1coef(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], addcovar=X[,-c(3,2)[phecol]])
+            Xcol2keep <- colnames(X)[colnames(X) %in% colnames(co)]
+            expected <- scan1coef(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], 
+                                  addcovar=X[,Xcol2keep])
             expect_equal(co, expected)
         }
     }
@@ -48,8 +49,9 @@ test_that("scan1 etc work with reduced-rank covariates", {
     for(phecol in 1:2) {
         for(chr in names(pr)) {
             co <- scan1coef(pr[,chr], phe[,phecol,drop=FALSE], k, addcovar=X)
-            # not clear which column to drop in 2nd case
-            expected <- scan1coef(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], k, addcovar=X[,-c(3,2)[phecol]])
+            Xcol2keep <- colnames(X)[colnames(X) %in% colnames(co)]
+            expected <- scan1coef(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], 
+                                  k, addcovar=X[,Xcol2keep])
             expect_equal(co, expected)
         }
     }
@@ -59,8 +61,9 @@ test_that("scan1 etc work with reduced-rank covariates", {
     for(phecol in 1:2) {
         for(chr in names(pr)) {
             co <- scan1blup(pr[,chr], phe[,phecol,drop=FALSE], addcovar=X)
-            # not clear which column to drop in 2nd case
-            expected <- scan1blup(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], addcovar=X[,-c(3,2)[phecol]])
+            Xcol2keep <- colnames(X)[colnames(X) %in% colnames(co)]
+            expected <- scan1blup(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], 
+                                  addcovar=X[,Xcol2keep])
             expect_equal(co, expected)
         }
     }
@@ -69,8 +72,9 @@ test_that("scan1 etc work with reduced-rank covariates", {
     for(phecol in 1:2) {
         for(chr in names(pr)) {
             co <- scan1blup(pr[,chr], phe[,phecol,drop=FALSE], k, addcovar=X)
-            # not clear which column to drop in 2nd case
-            expected <- scan1blup(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], k, addcovar=X[,-c(3,2)[phecol]])
+            Xcol2keep <- colnames(X)[colnames(X) %in% colnames(co)]
+            expected <- scan1blup(pr[,chr], phe[!is.na(phe[,phecol]),phecol,drop=FALSE], 
+                                  k, addcovar=X[,Xcol2keep])
             expect_equal(co, expected)
         }
     }

--- a/tests/testthat/test-scan1perm.R
+++ b/tests/testthat/test-scan1perm.R
@@ -241,7 +241,7 @@ test_that("scan1 permutations work with single kinship matrix (regression test)"
     attr(L, "is_x_chr") <- c(A=FALSE, X=TRUE)
     attr(expected, "chr_lengths") <- L
     class(expected) <- c("scan1perm", "list")
-    expect_equal(operm, expected, tolerance=1e-7)
+    expect_equal(operm, expected, tolerance=4e-7)
 
 })
 
@@ -323,10 +323,10 @@ test_that("scan1 permutations work with LOCO kinship matrix (regression test)", 
     expected <- cbind(liver= c(1.56455340995486880118, 1.0297698518383779920, 2.0850243087458522062),
                       spleen=c(0.91750143650706161846, 1.0096069617524108253, 2.8456095237817189414))
     class(expected) <- c("scan1perm", "matrix")
-    expect_equal(operm, expected, tolerance=1e-7)
+    expect_equal(operm, expected, tolerance=2e-7)
     set.seed(seed)
     operm <- scan1perm(pr, pheno2, kinship_loco, addcovar=sex, Xcovar=Xcovar, n_perm=3, perm_strata=perm_strata)
-    expect_equal(operm, expected, tolerance=1e-7)
+    expect_equal(operm, expected, tolerance=2e-7)
 
     # one missing phenotype, sex and X-chr covariates, plus sex interactive
     set.seed(seed)
@@ -356,6 +356,6 @@ test_that("scan1 permutations work with LOCO kinship matrix (regression test)", 
     attr(L, "is_x_chr") <- c(A=FALSE, X=TRUE)
     attr(expected, "chr_lengths") <- L
     class(expected) <- c("scan1perm", "list")
-    expect_equal(operm, expected, tolerance=1e-7)
+    expect_equal(operm, expected, tolerance=2e-7)
 
 })


### PR DESCRIPTION
In `interp_map()`:

- Deal with case of missing marker names
- Deal with case of non-unique marker names
- Do a better job in the case that some markers are at identical positions in the `oldmap` (if markers are in both `map` and `oldmap`, keep them in the locations that they were found in `newmap`.

Also make small changes to tests to get them to pass on Win32.